### PR TITLE
Removed 'UTC' from timestamp string

### DIFF
--- a/src/scrobblify.ts
+++ b/src/scrobblify.ts
@@ -52,7 +52,7 @@ export default class Scrobblify {
       return new SpotifyListen(
         allArtists[0], // The first artist is the one we'll use to scrobble
         play.trackName,
-        new Date(`${play.endTime} UTC`),
+        new Date(`${play.endTime}`),
         play.msPlayed,
       );
     });


### PR DESCRIPTION
Removed 'UTC' from timestamp string. It was causing Date constructor to return Invalid Date, so all plays appeared to be older than 2 weeks.

The timestamps from Spotify data don't seem to be in UTC, anyway.