### PR TITLE
Add PostHog analytics for error visibility and usage tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/blueimp-md5": "^2.7.0",
         "blueimp-md5": "^2.12.0",
         "jszip": "^3.10.1",
+        "posthog-js": "^1.399.0",
         "string-similarity": "^4.0.1",
         "vue": "^2.6.11",
         "vue-class-component": "^7.2.3",
@@ -1852,6 +1853,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@posthog/core": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.40.0.tgz",
+      "integrity": "sha512-oGDbIwlTquNwdHbEL5ZLEkuW4UFkkEanfx3QAxDgyVbISv+OAA6YGQwrvo0JD3MUJEbJZvyh8XsX+WYDGw9XHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.393.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.393.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.393.0.tgz",
+      "integrity": "sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==",
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -2241,6 +2257,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/webpack-env": {
       "version": "1.18.8",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.8.tgz",
@@ -2372,18 +2395,6 @@
         "vue": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vue/babel-preset-app/node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/@vue/babel-preset-app/node_modules/semver": {
@@ -4493,6 +4504,17 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
@@ -5239,6 +5261,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -5784,6 +5815,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -9323,6 +9360,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.399.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.399.0.tgz",
+      "integrity": "sha512-8l+uZJZM3+OAc0D0+iLBMDRVfWF9s26Rt0jv8EC3kMJcA/9oyOets0zDgqIZk2TTfUs3H96ycLE6Lwj1wWG16Q==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/core": "^1.40.0",
+        "@posthog/types": "^1.393.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -9425,6 +9496,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -11475,6 +11552,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/blueimp-md5": "^2.7.0",
     "blueimp-md5": "^2.12.0",
     "jszip": "^3.10.1",
+    "posthog-js": "^1.399.0",
     "string-similarity": "^4.0.1",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",

--- a/src/components/AuthenticateStep.vue
+++ b/src/components/AuthenticateStep.vue
@@ -18,6 +18,7 @@
 import Vue from 'vue';
 import LastFm from '@/api/LastFm';
 import ErrorDialog from '@/components/ErrorDialog.vue';
+import { trackEvent, trackError, identifyUser } from '@/services/Analytics';
 export default Vue.extend({
   components: { 'error-dialog': ErrorDialog },
   data() {
@@ -39,6 +40,8 @@ export default Vue.extend({
     try {
       await api.init(this.$route.query);
     } catch (e) {
+      trackError('auth.init', e);
+      trackEvent('auth_failed');
       this.$data.checkingAuth = false;
       this.errorMessage = 'Failed to authenticate with Last.fm. Please try again.';
       this.errorDetails = (e as Error).message || String(e);
@@ -46,6 +49,8 @@ export default Vue.extend({
       return;
     }
     if (api.isAuthenticated()) {
+      identifyUser(api.getUserName());
+      trackEvent('auth_success', { returning: !this.$route.query.token });
       setTimeout(() => {
         this.$emit('complete');
       }, 2000);

--- a/src/components/ScrobbleStep.vue
+++ b/src/components/ScrobbleStep.vue
@@ -77,6 +77,7 @@ import Vue from 'vue';
 import Scrobble from '@/models/Scrobble';
 import LastFm from '@/api/LastFm';
 import ErrorDialog from '@/components/ErrorDialog.vue';
+import { trackEvent, trackError } from '@/services/Analytics';
 
 const BURST_LIMIT = 950;
 const DAILY_LIMIT = 2700;
@@ -130,6 +131,15 @@ export default Vue.extend({
       let consecutiveFailures = 0;
       const MAX_CONSECUTIVE_FAILURES = 10;
 
+      if (this.scrobbledTracks === 0) {
+        trackEvent('scrobble_started', { total_tracks: tracks.length });
+      } else {
+        trackEvent('scrobble_resumed', {
+          total_tracks: tracks.length,
+          already_scrobbled: this.scrobbledTracks,
+        });
+      }
+
       for (let i = this.scrobbledTracks; i < tracks.length; i++) {
         // Check if manually paused
         if (this.paused) {
@@ -139,6 +149,7 @@ export default Vue.extend({
         // Check burst limit
         if (this.burstCount >= BURST_LIMIT) {
           this.pauseReason = `Approaching Last.fm's burst limit (~1,000 scrobbles). Pausing for 10 minutes to avoid being rate-limited.`;
+          trackEvent('scrobble_paused', { reason: 'burst_limit', scrobbled_tracks: this.scrobbledTracks });
           await this.pauseWithCountdown(BURST_COOLDOWN_MS);
           this.burstCount = 0;
         }
@@ -146,6 +157,7 @@ export default Vue.extend({
         // Check daily limit
         if (this.dailyCount >= DAILY_LIMIT) {
           this.pauseReason = `Approaching Last.fm's daily limit (~2,800 scrobbles). You'll need to come back tomorrow to continue.`;
+          trackEvent('scrobble_paused', { reason: 'daily_limit', scrobbled_tracks: this.scrobbledTracks });
           this.paused = true;
           return;
         }
@@ -165,6 +177,11 @@ export default Vue.extend({
           consecutiveFailures++;
 
           if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            trackError('scrobble.repeatedFailures', e, {
+              consecutive_failures: consecutiveFailures,
+              scrobbled_tracks: this.scrobbledTracks,
+              failed_tracks: this.failedTracks.length,
+            });
             this.errorMessage = `${MAX_CONSECUTIVE_FAILURES} tracks failed in a row. There may be a problem with Last.fm or your authentication.`;
             this.errorDetails = (e as Error).message || String(e);
             this.showError = true;
@@ -178,6 +195,11 @@ export default Vue.extend({
       }
 
       this.completed = true;
+      trackEvent('scrobble_completed', {
+        total_tracks: tracks.length,
+        scrobbled_tracks: this.scrobbledTracks,
+        failed_tracks: this.failedTracks.length,
+      });
       this.$emit('complete');
     },
 
@@ -203,6 +225,7 @@ export default Vue.extend({
 
     manualPause() {
       this.pauseReason = 'Manually paused.';
+      trackEvent('scrobble_paused', { reason: 'manual', scrobbled_tracks: this.scrobbledTracks });
       this.paused = true;
     },
 

--- a/src/components/Scrobblify.vue
+++ b/src/components/Scrobblify.vue
@@ -74,7 +74,7 @@ import ScrobbleStepVue from '@/components/ScrobbleStep.vue';
 import CompleteStepVue from '@/components/CompleteStep.vue';
 import StateManager, { ScrobbleState } from '@/services/StateManager';
 import ErrorDialog from '@/components/ErrorDialog.vue';
-
+import { trackEvent, trackError, resetUser } from '@/services/Analytics';
 
 export default Vue.extend({
   components: {
@@ -97,24 +97,37 @@ export default Vue.extend({
     };
   },
   async mounted() {
+    trackEvent('step_viewed', { step: this.currentStep, step_name: this.stepName(this.currentStep) });
     try {
       this.hasResumableState = await this.stateManager.hasSavedState();
     } catch (e) {
       // IndexedDB not available — not critical, just skip resume
     }
   },
+  watch: {
+    currentStep(step: number) {
+      trackEvent('step_viewed', { step, step_name: this.stepName(step) });
+    },
+  },
   methods: {
+    stepName(step: number): string {
+      return ['', 'authenticate', 'upload', 'select', 'scrobble', 'complete'][step] || String(step);
+    },
     clearToken() {
       const api = this.$store.state.lfmApi as LastFm;
       this.currentStep = 1;
       api.clearUser();
+      resetUser();
+      trackEvent('user_logged_out');
     },
     async resumeFromSaved() {
       try {
         const state = await this.stateManager.loadState();
         if (!state) { return; }
+        trackEvent('session_resumed', { source: 'saved', total_tracks: state.totalTracks });
         this.restoreFromState(state);
       } catch (e) {
+        trackError('scrobblify.resumeFromSaved', e);
         this.errorMessage = 'Failed to load your saved progress.';
         this.errorDetails = (e as Error).message || String(e);
         this.showError = true;
@@ -128,8 +141,10 @@ export default Vue.extend({
       if (!input.files || input.files.length === 0) { return; }
       try {
         const state = await this.stateManager.importFromFile(input.files[0]);
+        trackEvent('session_resumed', { source: 'file', total_tracks: state.totalTracks });
         this.restoreFromState(state);
       } catch (e) {
+        trackError('scrobblify.onImportFile', e);
         this.errorMessage = 'The selected file is not a valid Scrobblify progress file.';
         this.errorDetails = (e as Error).message || String(e);
         this.showError = true;
@@ -194,7 +209,12 @@ export default Vue.extend({
       try {
         await this.stateManager.saveState(state);
         this.stateManager.exportToFile(state);
+        trackEvent('session_saved', {
+          scrobbled_tracks: info.scrobbledTracks,
+          total_tracks: tracks.length,
+        });
       } catch (e) {
+        trackError('scrobblify.onSaveAndExit', e);
         this.errorMessage = 'Failed to save your scrobbling progress. You can try the "Save Progress" button again.';
         this.errorDetails = (e as Error).message || String(e);
         this.showError = true;

--- a/src/components/SelectStep.vue
+++ b/src/components/SelectStep.vue
@@ -155,6 +155,7 @@
 import Vue from 'vue';
 import Scrobble from '@/models/Scrobble';
 import SpotifyListen from '@/models/SpotifyListen';
+import { trackEvent } from '@/services/Analytics';
 
 const workerCode = `
   let count = 0;
@@ -501,6 +502,10 @@ export default Vue.extend({
       this.$store.commit('setSelectedScrobbles', selected.map((track: any) => {
         return new Scrobble(track.track, track.artist, new Date(track.time), track.album);
       }));
+      trackEvent('tracks_selected', {
+        selected_count: selected.length,
+        total_count: this.totalTrackCount,
+      });
       this.$emit('complete');
     },
   },

--- a/src/components/UploadStep.vue
+++ b/src/components/UploadStep.vue
@@ -76,6 +76,7 @@ import JSZip from 'jszip';
 import Scrobblify from '@/scrobblify';
 import SpotifyListen from '@/models/SpotifyListen';
 import ErrorDialog from '@/components/ErrorDialog.vue';
+import { trackEvent, trackError } from '@/services/Analytics';
 
 function delay(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -143,6 +144,13 @@ export default Vue.extend({
     async parseSpotifyData() {
       if (!this.selectedFile) { return; }
 
+      trackEvent('upload_parse_started', {
+        file_size_bytes: this.selectedFile.size,
+        scrobble_old_plays: this.scrobbleOldPlays,
+        follow_lfm_rules: this.followLfmRules,
+        check_duplicates: this.checkDuplicates,
+      });
+
       const reTagDate = new Date();
       this.logs.push('Reading ZIP file...');
       await delay(100);
@@ -151,6 +159,7 @@ export default Vue.extend({
       try {
         zip = await JSZip.loadAsync(this.selectedFile);
       } catch (e) {
+        trackError('upload.loadZip', e);
         this.errorMessage = 'Failed to read the ZIP file. It may be corrupted or not a valid ZIP archive.';
         this.errorDetails = (e as Error).message || String(e);
         this.showError = true;
@@ -162,6 +171,7 @@ export default Vue.extend({
       );
 
       if (matchingFiles.length === 0) {
+        trackEvent('upload_no_matching_files');
         this.errorMessage = 'No Streaming_History_Audio_*.json files found in the ZIP. Make sure you uploaded the correct Spotify Extended Streaming History export.';
         this.showError = true;
         return;
@@ -183,6 +193,7 @@ export default Vue.extend({
         try {
           jsonString = await zip.files[name].async('string');
         } catch (e) {
+          trackError('upload.extractFile', e, { file: shortName });
           this.errorMessage = `Failed to extract "${shortName}" from the ZIP archive.`;
           this.errorDetails = (e as Error).message || String(e);
           this.showError = true;
@@ -192,6 +203,7 @@ export default Vue.extend({
         try {
           parsedData = parsedData.concat(this.scrobblify.spotifyJsonToListens(jsonString));
         } catch (e) {
+          trackError('upload.parseJson', e, { file: shortName });
           this.errorMessage = `Failed to parse "${shortName}". The JSON data in this file may be malformed.`;
           this.errorDetails = (e as Error).message || String(e);
           this.showError = true;
@@ -227,6 +239,7 @@ export default Vue.extend({
       try {
         validData = await this.scrobblify.removeInvalidListens(newData, this.smartMoveProgress, !this.followLfmRules);
       } catch (e) {
+        trackError('upload.removeInvalidListens', e);
         this.errorMessage = 'An error occurred while validating your listening history.';
         this.errorDetails = (e as Error).message || String(e);
         this.showError = true;
@@ -256,6 +269,7 @@ export default Vue.extend({
           toBeScrobbled = result.unique;
           this.logs.push(`Found ${result.duplicateCount} duplicates — ${toBeScrobbled.length} new tracks to scrobble.`);
         } catch (e) {
+          trackError('upload.filterDuplicates', e);
           this.errorMessage = 'An error occurred while checking for duplicates. Proceeding with all tracks.';
           this.errorDetails = (e as Error).message || String(e);
           this.showError = true;
@@ -266,6 +280,12 @@ export default Vue.extend({
       this.logs.push(`Ready to scrobble ${toBeScrobbled.length} tracks.`);
       this.readyToScrobble = true;
       this.$store.commit('setValidScrobbles', toBeScrobbled);
+      trackEvent('upload_parse_completed', {
+        total_plays: parsedData.length,
+        valid_count: validData.length,
+        to_scrobble_count: toBeScrobbled.length,
+        checked_duplicates: this.checkDuplicates,
+      });
     },
   },
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,26 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import vuetify from './plugins/vuetify';
+import { initAnalytics, registerGlobalErrorHandlers, trackError, trackPageView } from '@/services/Analytics';
 
 Vue.config.productionTip = false;
+
+initAnalytics();
+registerGlobalErrorHandlers();
+
+// Capture uncaught errors thrown inside Vue components/lifecycle hooks.
+Vue.config.errorHandler = (err, vm, info) => {
+  trackError('vue.errorHandler', err, { info });
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+};
+
+// SPA page-view tracking (autocapture is disabled).
+router.afterEach((to) => {
+  trackPageView(to.fullPath);
+});
 
 new Vue({
   router,

--- a/src/services/Analytics.ts
+++ b/src/services/Analytics.ts
@@ -1,0 +1,136 @@
+import posthog from 'posthog-js';
+
+/*
+  Lightweight wrapper around PostHog. Its purpose is to give visibility into
+  where users run into errors so they can be helped. Analytics must NEVER break
+  the app — every call is wrapped in a try/catch and silently ignored on failure.
+
+  This project shares a PostHog instance with LastWave, so every event is tagged
+  with `app: 'scrobblify'` (see APP_NAME) to keep the two apps' data separable.
+
+  The key/host can be overridden at build time via VUE_APP_POSTHOG_KEY /
+  VUE_APP_POSTHOG_HOST, but sensible defaults are baked in (the project API key
+  is a public, client-side token, matching how the Last.fm keys are stored).
+*/
+const POSTHOG_KEY = process.env.VUE_APP_POSTHOG_KEY || 'phc_nhGFP4vdzuGrL5B7VGoeGRKcAtnPMvEsumoWhWTkp4a5';
+const POSTHOG_HOST = process.env.VUE_APP_POSTHOG_HOST || 'https://us.i.posthog.com';
+const APP_NAME = 'scrobblify';
+
+let initialized = false;
+
+export function initAnalytics(): void {
+  if (initialized || !POSTHOG_KEY) {
+    return;
+  }
+  // Don't pollute the (shared) production project with local dev / e2e-test
+  // events. Only real users hitting the deployed site are tracked.
+  const host = window.location.hostname;
+  if (host === 'localhost' || host === '127.0.0.1' || host === '') {
+    return;
+  }
+  try {
+    posthog.init(POSTHOG_KEY, {
+      api_host: POSTHOG_HOST,
+      // Usage is tracked with explicit events, not automatic click/DOM capture.
+      autocapture: false,
+      capture_pageview: false,
+      persistence: 'localStorage+cookie',
+    });
+    posthog.register({ app: APP_NAME });
+    initialized = true;
+  } catch (e) {
+    // Analytics is best-effort; never let it break the app.
+  }
+}
+
+export function trackEvent(event: string, properties: Record<string, any> = {}): void {
+  if (!initialized) {
+    return;
+  }
+  try {
+    posthog.capture(event, properties);
+  } catch (e) {
+    // ignore
+  }
+}
+
+export function trackPageView(path: string): void {
+  if (!initialized) {
+    return;
+  }
+  try {
+    posthog.capture('$pageview', { $current_url: window.location.href, path });
+  } catch (e) {
+    // ignore
+  }
+}
+
+/*
+  Records an error against a named context (e.g. 'upload.parseZip') so failures
+  can be grouped and investigated. Captures both a filterable custom event and,
+  when available, PostHog's native exception so it shows up in error tracking.
+*/
+export function trackError(context: string, error: unknown, extra: Record<string, any> = {}): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+
+  if (initialized) {
+    try {
+      posthog.capture('scrobblify_error', {
+        context,
+        message: err.message,
+        stack: err.stack,
+        ...extra,
+      });
+      const captureException = (posthog as any).captureException;
+      if (typeof captureException === 'function') {
+        captureException.call(posthog, err, { context, ...extra });
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error(`[scrobblify:${context}]`, err, extra);
+  }
+}
+
+/*
+  Associates subsequent events with the user's Last.fm username. This makes it
+  possible to look up a specific user's session when they report a problem.
+*/
+export function identifyUser(userName: string | null): void {
+  if (!initialized || !userName) {
+    return;
+  }
+  try {
+    posthog.identify(userName, { lastfm_username: userName });
+  } catch (e) {
+    // ignore
+  }
+}
+
+export function resetUser(): void {
+  if (!initialized) {
+    return;
+  }
+  try {
+    posthog.reset();
+  } catch (e) {
+    // ignore
+  }
+}
+
+export function registerGlobalErrorHandlers(): void {
+  window.addEventListener('error', (event: ErrorEvent) => {
+    trackError('window.onerror', event.error || event.message, {
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    });
+  });
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    trackError('unhandledrejection', event.reason);
+  });
+}


### PR DESCRIPTION
## Summary
Adds PostHog logging to Scrobblify so we can see when users hit errors and help fix them, plus a lightweight usage funnel.

The core is a crash-proof wrapper in `src/services/Analytics.ts` — every call is `try/catch`-guarded so analytics can never break the app.

## What's captured
**Errors (the main goal)**
- Global handlers: `window.onerror`, `unhandledrejection`, `Vue.config.errorHandler`
- `trackError()` at every existing failure point: Last.fm auth, ZIP read/extract, JSON parse, validation, duplicate check, repeated scrobble failures, and state save/resume/import
- Sends both a filterable `scrobblify_error` event (context + message + stack) and PostHog's native exception capture

**Usage funnel**
- `step_viewed`, `auth_success`/`auth_failed`, `upload_parse_started`/`upload_parse_completed`, `tracks_selected`, `scrobble_started`/`scrobble_paused`/`scrobble_completed`, `session_saved`/`session_resumed`, `user_logged_out`
- `identifyUser()` tags sessions with the Last.fm username so a reported problem maps to a real session

## Notes
- Reuses the existing **LastWave PostHog project**; every event is tagged `app: 'scrobblify'` so the two apps' data stay separable.
- Analytics init is **skipped on localhost** to avoid polluting production data.
- Key/host are overridable via `VUE_APP_POSTHOG_KEY` / `VUE_APP_POSTHOG_HOST`, with the public client-side key baked in as a default (matching how the Last.fm keys are stored).

## Testing
- `npm run build` passes (only pre-existing bundle-size warnings)
- Playwright: 25/25 pass