### PR TITLE
Add mocked local dev harness, shared Last.fm mock, and agent notes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "posthog": {
+      "type": "http",
+      "url": "https://mcp.posthog.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${POSTHOG_MCP_TOKEN}"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# Agent notes for scrobblify
+
+## Debugging with PostHog
+
+This app reports usage and errors to PostHog from the browser. The PostHog MCP
+server is configured in `.mcp.json` at the repo root, so any MCP-aware agent
+picks it up automatically.
+
+### Setup (once per machine)
+
+`.mcp.json` reads the token from an environment variable — **never commit a key**.
+
+1. Create a personal API key with the **MCP Server** preset:
+   https://app.posthog.com/settings/user-api-keys?preset=mcp_server
+2. Export it as `POSTHOG_MCP_TOKEN` in your shell profile.
+
+Verify with `copilot mcp get posthog`.
+
+### Project layout
+
+The PostHog project is **shared with LastWave**. Every scrobblify event is tagged
+with `app` (see `APP_NAME` in `src/services/Analytics.ts`); LastWave's events
+carry no `app` property at all, so **always filter `properties.app = 'scrobblify'`**
+or you will be reading another app's data.
+
+Nothing is captured from `localhost` / `127.0.0.1`, `autocapture` and
+`capture_pageview` are disabled, and all analytics failures are swallowed
+silently. Absence of events is not evidence that a code path did not run.
+
+Users are identified by their Last.fm username (`lastfm_username`), so a bug
+report from a named user can be traced to their session.
+
+### Errors
+
+Errors arrive two ways: a filterable `scrobblify_error` event (properties:
+`context`, `message`, `stack`) and, where supported, a native PostHog exception.
+`context` is the grouping key. Current values:
+
+| Area | `context` values |
+| --- | --- |
+| Upload / parsing | `upload.loadZip`, `upload.extractFile`, `upload.parseJson`, `upload.removeInvalidListens`, `upload.filterDuplicates` |
+| Auth | `auth.init`, `auth.strip_token_url` |
+| Scrobbling | `scrobble.repeatedFailures` |
+| Session state | `scrobblify.resumeFromSaved`, `scrobblify.onImportFile`, `scrobblify.onSaveAndExit` |
+| Uncaught | `vue.errorHandler`, `window.onerror`, `unhandledrejection` |
+
+Last.fm failures are normalized to `Last.fm API error <code> (HTTP <status>)`
+so they group cleanly, and credentials (`token`, `sk`, `api_sig`, `api_key`) are
+replaced with `[redacted]`. **Never widen an error message to include raw request
+params** — an early version leaked a user's Last.fm session key into analytics.
+
+### Funnel events
+
+`step_viewed` → `auth_success` / `auth_failed` / `auth_token_invalid` →
+`upload_parse_started` / `upload_parse_completed` / `upload_no_matching_files` →
+`tracks_selected` → `scrobble_started` / `scrobble_resumed` / `scrobble_paused` /
+`scrobble_completed`, plus `session_saved`, `session_resumed`, and
+`user_logged_out`.
+
+Rate limiting has its own events: `scrobble_rate_limited`,
+`scrobble_rate_limit_cooldown_complete`, and `scrobble_rate_limit_recovered`.
+Network failures emit `scrobble_network_error`.
+
+`scrobble_paused` carries a `reason` of `burst_limit`, `daily_limit`, or `manual`
+— the first two are Last.fm rate limiting, not bugs. These dominate by volume
+(`scrobble_paused` and `scrobble_rate_limited` are the highest-count events after
+`step_viewed`), so treat them as normal operation, not signal.
+
+### Adding instrumentation
+
+Use the helpers in `src/services/Analytics.ts` (`trackEvent`, `trackError`,
+`identifyUser`) rather than calling `posthog` directly. Analytics must never
+break the app: every call is wrapped in try/catch and ignored on failure.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "dev:mock": "node tests/dev-mock.js"
   },
   "dependencies": {
     "@types/blueimp-md5": "^2.7.0",

--- a/tests/dev-mock.js
+++ b/tests/dev-mock.js
@@ -1,0 +1,123 @@
+// Interactive local run of Scrobblify with Last.fm fully mocked.
+//
+//   npm run dev:mock
+//
+// Opens a real (headed) Chromium window pointed at the dev server, intercepts
+// every Last.fm API call with canned responses, and pre-seeds the logged-in
+// state — so you can click through the whole upload -> select -> scrobble flow
+// without a real Last.fm account. Reuses the exact mock the Playwright tests
+// use (tests/lastfmMock.js).
+//
+// If a dev server is already running on port 8080 it is reused; otherwise this
+// script starts `vue-cli-service serve` for you and shuts it down on exit.
+
+const http = require('http');
+const { spawn } = require('child_process');
+const { chromium } = require('@playwright/test');
+const { interceptLastFm, mockLastFmAuth } = require('./lastfmMock');
+
+const PORT = 8080;
+const BASE_URL = `http://localhost:${PORT}`;
+const START_PATH = '/#/scrobble';
+
+function isServerUp() {
+  return new Promise((resolve) => {
+    const req = http.get(BASE_URL, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(1500, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForServer(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await isServerUp()) {
+      return true;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return false;
+}
+
+async function main() {
+  let serverProc = null;
+
+  if (await isServerUp()) {
+    console.log(`✓ Reusing dev server already running at ${BASE_URL}`);
+  } else {
+    console.log(`Starting dev server (vue-cli-service serve) on port ${PORT}...`);
+    serverProc = spawn(
+      'npx',
+      ['vue-cli-service', 'serve', '--port', String(PORT)],
+      { stdio: 'inherit', shell: true },
+    );
+    serverProc.on('exit', (code) => {
+      if (code && code !== 0) {
+        console.error(`Dev server exited with code ${code}`);
+        process.exit(code);
+      }
+    });
+
+    console.log('Waiting for dev server to become ready...');
+    const ready = await waitForServer(90000);
+    if (!ready) {
+      console.error('Dev server did not start within 90s.');
+      if (serverProc) {
+        serverProc.kill();
+      }
+      process.exit(1);
+    }
+    console.log('✓ Dev server is ready.');
+  }
+
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+
+  // Install the shared Last.fm mock before any navigation.
+  await interceptLastFm(page);
+
+  // Establish the origin so localStorage is writable, seed auth, then reload so
+  // the app's init() picks up the "logged in" session from localStorage.
+  await page.goto(BASE_URL + START_PATH);
+  await mockLastFmAuth(page);
+  await page.reload();
+
+  console.log('');
+  console.log('==================================================================');
+  console.log('  Scrobblify is running with Last.fm MOCKED.');
+  console.log(`  URL:  ${BASE_URL}${START_PATH}`);
+  console.log('  You are auto-authenticated as "testuser" — no real account used.');
+  console.log('  All Last.fm calls return canned data; nothing is really scrobbled.');
+  console.log('  Close the browser window (or press Ctrl+C) to stop.');
+  console.log('==================================================================');
+  console.log('');
+
+  const shutdown = async () => {
+    try {
+      await browser.close();
+    } catch (e) { /* already closed */ }
+    if (serverProc) {
+      serverProc.kill();
+    }
+    process.exit(0);
+  };
+
+  // Exit when the user closes the browser window.
+  browser.on('disconnected', shutdown);
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/lastfmMock.d.ts
+++ b/tests/lastfmMock.d.ts
@@ -1,0 +1,4 @@
+import { Page } from '@playwright/test';
+
+export function interceptLastFm(page: Page): Promise<void>;
+export function mockLastFmAuth(page: Page): Promise<void>;

--- a/tests/lastfmMock.js
+++ b/tests/lastfmMock.js
@@ -1,0 +1,72 @@
+// Shared Last.fm mock used by both the Playwright test suite (scrobblify.spec.ts)
+// and the interactive `npm run dev:mock` script (dev-mock.js).
+//
+// Intercepts every request to https://ws.audioscrobbler.com/** and returns
+// canned responses, so the app can be exercised end-to-end without a real
+// Last.fm account.
+
+// Intercept all Last.fm API calls and fulfill them with fake data.
+function interceptLastFm(page) {
+  return page.route('https://ws.audioscrobbler.com/**', async (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    const postData = route.request().postData() || '';
+    const allParams = new URLSearchParams(
+      method === 'POST' ? postData : new URL(url).search,
+    );
+    const apiMethod = allParams.get('method');
+
+    if (apiMethod === 'auth.getSession') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          session: { name: 'testuser', key: 'fake-session-key', subscriber: 0 },
+        }),
+      });
+    } else if (apiMethod === 'track.getInfo') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          track: { duration: '240000', name: allParams.get('track'), artist: { name: allParams.get('artist') } },
+        }),
+      });
+    } else if (apiMethod === 'user.getrecenttracks') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          recenttracks: { track: [] },
+        }),
+      });
+    } else if (apiMethod === 'track.scrobble') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scrobbles: { '@attr': { accepted: 1, ignored: 0 } },
+        }),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    }
+  });
+}
+
+// Seed localStorage so the app believes it's already authenticated with Last.fm.
+// Must be called AFTER a page.goto() so we're on the same origin.
+async function mockLastFmAuth(page) {
+  await page.evaluate(() => {
+    localStorage.setItem('scrobblifyLfmAuthToken', 'fake-token');
+    localStorage.setItem('scrobblifyLfmAuthKey', 'fake-session-key');
+    localStorage.setItem('scrobblifyLfmUserName', 'testuser');
+  });
+}
+
+module.exports = { interceptLastFm, mockLastFmAuth };

--- a/tests/scrobblify.spec.ts
+++ b/tests/scrobblify.spec.ts
@@ -2,72 +2,10 @@ import { test, expect, Page, Route } from '@playwright/test';
 import path from 'path';
 import LastFm from '../src/api/LastFm';
 import Scrobble from '../src/models/Scrobble';
+// Shared Last.fm mock, also used by the `npm run dev:mock` interactive script.
+import { interceptLastFm, mockLastFmAuth } from './lastfmMock';
 
 const FIXTURE_ZIP = path.resolve(__dirname, 'fixtures', 'test-spotify-data.zip');
-
-// Helper: mock Last.fm auth so the app thinks we're logged in.
-// Must be called AFTER a page.goto() so we're on the same origin.
-async function mockLastFmAuth(page: Page) {
-  await page.evaluate(() => {
-    localStorage.setItem('scrobblifyLfmAuthToken', 'fake-token');
-    localStorage.setItem('scrobblifyLfmAuthKey', 'fake-session-key');
-    localStorage.setItem('scrobblifyLfmUserName', 'testuser');
-  });
-}
-
-// Helper: intercept all Last.fm API calls
-function interceptLastFm(page: Page) {
-  return page.route('https://ws.audioscrobbler.com/**', async (route: Route) => {
-    const url = route.request().url();
-    const method = route.request().method();
-
-    const postData = route.request().postData() || '';
-    const allParams = new URLSearchParams(
-      method === 'POST' ? postData : new URL(url).search,
-    );
-    const apiMethod = allParams.get('method');
-
-    if (apiMethod === 'auth.getSession') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          session: { name: 'testuser', key: 'fake-session-key', subscriber: 0 },
-        }),
-      });
-    } else if (apiMethod === 'track.getInfo') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          track: { duration: '240000', name: allParams.get('track'), artist: { name: allParams.get('artist') } },
-        }),
-      });
-    } else if (apiMethod === 'user.getrecenttracks') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          recenttracks: { track: [] },
-        }),
-      });
-    } else if (apiMethod === 'track.scrobble') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          scrobbles: { '@attr': { accepted: 1, ignored: 0 } },
-        }),
-      });
-    } else {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({}),
-      });
-    }
-  });
-}
 
 // Navigate past auth (step 1 -> step 2) with mocked auth
 async function goToUploadStep(page: Page) {


### PR DESCRIPTION
## What

Adds a way to run the whole app locally with Last.fm mocked, plus the PostHog notes an agent needs to debug production issues.

### `npm run dev:mock`
`tests/dev-mock.js` reuses a dev server on port 8080 (or starts one), opens a headed Chromium with every `ws.audioscrobbler.com` call intercepted, and pre-seeds the session as `testuser`. The full upload -> select -> scrobble flow is clickable without a real Last.fm account, and nothing is really scrobbled.

### Shared Last.fm mock
The route interceptor and localStorage auth seeding moved out of `tests/scrobblify.spec.ts` into `tests/lastfmMock.js` (typings in `tests/lastfmMock.d.ts`), so the tests and the interactive script share one set of canned responses. The spec change is a pure extraction - no test was added, removed, or altered.

### `AGENTS.md` + `.mcp.json`
Documents the PostHog project layout, most importantly that it is **shared with LastWave**, so every query must filter `properties.app = ''scrobblify''`. Also captures the `scrobblify_error` `context` values, the funnel/rate-limit events, and the rule that error messages must never be widened to include raw request params - an early version leaked a user session key into analytics. `.mcp.json` wires up the PostHog MCP server and reads the token from `POSTHOG_MCP_TOKEN`; no key is committed.

## Testing

`npx playwright test` - 28/28 pass. `npm run dev:mock` verified end to end: server boots, browser opens, mock installed, auto-authenticated.

Note: `Home Page > renders home page with instructions` is flaky on a cold start - it navigates before webpack finishes its first compile and lands right at the 30s timeout (29.0s when re-run alone). Pre-existing on `master`, untouched here.
