### PR TITLE
Fix repeat listens being silently dropped, and rate-limit handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,19 +58,88 @@ params** — an early version leaked a user's Last.fm session key into analytics
 `user_logged_out`.
 
 Rate limiting has its own events: `scrobble_rate_limited`,
-`scrobble_rate_limit_cooldown_complete`, and `scrobble_rate_limit_recovered`.
-Network failures emit `scrobble_network_error`.
+`scrobble_rate_limit_cooldown_complete`, `scrobble_rate_limit_recovered`,
+`scrobble_rate_limit_gave_up` (the escalating backoff was exhausted and progress
+was auto-saved), and `scrobble_burst_limit_lowered` / `scrobble_burst_limit_raised`
+from the adaptive limit in `RateLimitTracker`. Network failures emit
+`scrobble_network_error`. `scrobble_ignored` fires when Last.fm accepts the
+request but discards the play (see below).
 
-`scrobble_paused` carries a `reason` of `burst_limit`, `daily_limit`, or `manual`
-— the first two are Last.fm rate limiting, not bugs. These dominate by volume
-(`scrobble_paused` and `scrobble_rate_limited` are the highest-count events after
-`step_viewed`), so treat them as normal operation, not signal.
+`scrobble_paused` carries a `reason` of `burst_limit`, `daily_limit`,
+`rate_limit`, `rate_limit_exhausted`, `network_error`, `lastfm_daily_limit`, or
+`manual` — only `manual` is a user action; the rest are Last.fm throttling, not
+bugs. These dominate by volume (`scrobble_paused` and `scrobble_rate_limited`
+are the highest-count events after `step_viewed`), so treat them as normal
+operation, not signal.
+
+### Measuring completion
+
+Do **not** build completion percentages from `scrobbled_tracks / total_tracks`.
+Those are session-scoped: a resume restores only the *remaining* tracks, so
+`total_tracks` shrinks on every resume and the ratio measures progress through
+the current chunk, not the import. Real examples: 81,313 → 573, 9,924 → 40.
+
+Every scrobble event carries resume-stable fields instead — use these:
+`original_total_tracks`, `total_succeeded`, `completion_pct`, `is_resumed`,
+`previously_scrobbled`. Note these only exist on events emitted after the
+telemetry fix, so older events cannot be compared against them.
+
+`total_succeeded` is still an **upper bound**: Last.fm silently discards a
+scrobble duplicating an existing (artist, track, timestamp) while reporting it
+as accepted, so re-scrobbling history a user already has inflates the count with
+no way to detect it from the API.
 
 ### Adding instrumentation
 
 Use the helpers in `src/services/Analytics.ts` (`trackEvent`, `trackError`,
 `identifyUser`) rather than calling `posthog` directly. Analytics must never
 break the app: every call is wrapped in try/catch and ignored on failure.
+
+## Scrobble timestamps
+
+Last.fm keys a scrobble on **(user, artist, track, timestamp)** and silently
+drops any repeat of that tuple — it still returns `accepted=1, ignored=0`, so
+the loss is **undetectable from the response**. This was verified experimentally
+against the live API; Last.fm does not document it and there is no
+`ignoredMessage` code for it. Uniqueness therefore has to be guaranteed
+client-side.
+
+An early version gave every play the *same* `Date` when the user ticked
+"Scrobble tracks older than 2 weeks" (~78% of imports), which collapsed all
+repeat listens of a track into a single scrobble.
+
+Plays that must be moved into Last.fm's 14-day window are flagged
+`reTagged` (`SpotifyListen` → `Scrobble` → `SerializedScrobble`). Their
+timestamps are **allocated at send time**, not at parse time, from a cursor in
+`ScrobbleStep`:
+
+```
+reTagCursorSec = min(nowSec, max(reTagCursorSec + 1, nowSec - RETAG_BACKFILL_SECONDS))
+```
+
+This matters because absolute timestamps baked in at parse time expire: a queue
+saved today and resumed three weeks later would be rejected wholesale with
+ignore code 3. The cursor is persisted as a high-water mark
+(`lastReTagTimestampSec`) so a resumed run can never reuse seconds an earlier
+run already sent.
+
+`scrobblePlay` returns a `ScrobbleResult`; a 200 does **not** mean the play was
+stored. Check `ignored` and `ignoredMessage.code` (1 artist ignored, 2 track
+ignored, 3 timestamp too old, 4 timestamp too new, 5 daily limit). Parsing
+deliberately defaults to *accepted* on an unrecognised shape so a surprise can
+never invent failures.
+
+Two consequences worth knowing before touching this code:
+
+- **A retry must re-send the identical timestamp.** It is allocated once per
+  track and held across attempts. If the original request reached Last.fm and
+  only the response was lost, an identical resend is deduplicated away; a fresh
+  second would become a phantom play.
+- **`filterDuplicates` skips `reTagged` listens.** Their timestamps are
+  provisional, so matching them against real history compares fiction against
+  fact and would silently drop import rows. Their true dates survive on
+  `originalListenDate`, but checking those would mean fetching the user's whole
+  Last.fm history back to the start of the export.
 
 ## Linting
 

--- a/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
+++ b/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
@@ -157,6 +157,27 @@ and decompressing the whole thing every tick, for every job, will exhaust both
 CPU and memory. Store **independently compressed chunks plus a manifest**, sized
 so a tick reads exactly the chunk its cursor points into.
 
+Chunking solves random access and introduces its own requirements. An
+authenticated user uploads arbitrary compressed bytes, so:
+
+- **Bound both compressed and uncompressed chunk size**, and enforce field length
+  and per-chunk entry count limits. Otherwise a small compression bomb exhausts
+  Worker memory at *scheduling* time, taking down every job on that tick rather
+  than just the attacker's.
+- **Hash every chunk** and validate on upload; write chunks with write-once
+  semantics so a chunk cannot be swapped after validation.
+- **Publish the manifest last**, and make the `active` transition conditional on
+  every chunk being present, hash-valid, and non-overlapping. Missing, duplicated,
+  or reordered chunks must be detectable from the manifest alone.
+
+### Listening history is personal data
+
+An earlier framing treated "no email, no password" as meaning there is no PII
+here. That is wrong as a threat model. A user's complete listening history,
+bound to their Last.fm username, is personal data — and the retained failed-track
+list is a subset of it. It should be minimised, deleted on the same schedule as
+the credential, and never logged into analytics.
+
 ### Portability requirements
 
 The worker must be movable to a plain VM without a rewrite:
@@ -205,27 +226,53 @@ only in Vuex (`SelectStep.vue:504-511`) and is **not** persisted, so a naive
 ordering below is easy to get wrong in ways that either strand a credential or
 lose an import.
 
-Required protocol:
+Required protocol. Note step 0 — an earlier draft had the SPA commit the digest
+only to `localStorage`, then had the worker "verify against the digest committed
+in step 1", which it had never been told. The nonce has the same problem: a
+worker-signed value cannot originate on the client.
 
-1. **Persist before leaving.** The SPA writes the selected track list to
-   `localStorage`/IndexedDB *before* redirecting, together with a
-   `pending_handoff` record holding a nonce, the expected Last.fm username, and a
-   SHA-256 digest of the serialised list.
-2. **Bind the nonce.** The `cb=` URL carries a worker-signed, single-use,
-   short-TTL nonce. The worker rejects any callback whose nonce is unknown,
-   expired, or already consumed.
+0. **Server preflight.** Before redirecting, the SPA calls the worker with the
+   expected Last.fm username, the payload's SHA-256 digest, the track count, and
+   the chunk manifest bounds. The worker durably records a `handoff` row in state
+   `issued` and returns a signed, single-use, short-TTL opaque state value. This
+   is what makes later verification possible at all.
+1. **Persist before leaving.** *Then* the SPA writes the selected track list to
+   IndexedDB, because a full-page redirect destroys Vuex.
+2. **Bind the callback.** The `cb=` URL carries the signed state from step 0. The
+   worker rejects any callback whose state is unknown, expired, already consumed,
+   or whose signature fails.
 3. **Verify the account.** `auth.getSession` returns a username. If it does not
-   match the username bound to the nonce, **abort and discard the session key.**
+   match the username recorded in step 0, **abort and discard the session key.**
    Without this check a user logged into a second Last.fm account in another tab
    — or an attacker who lands their own callback — has one account's history
    written into another's. This is the single most damaging failure mode in the
    design.
-4. **Upload, then finalise.** The job is created in `pending_upload`. The SPA
-   uploads the blob; the worker verifies the digest matches the one committed in
-   step 1, then transitions the job to `active`.
+4. **Upload, then finalise.** The job sits in `pending_upload`. The SPA uploads
+   chunks; the worker validates each chunk's hash, publishes the manifest last,
+   and only then transitions to `active`.
 5. **Clear last.** The SPA clears its own session key and cached list only after
    the worker confirms `active`. Clearing first turns any upload failure into
    total data loss.
+
+#### States, because the happy path is the easy part
+
+The transitions are `issued → exchanging → pending_upload → finalizing → active`,
+every one an atomic compare-and-set from the expected prior state. Callback and
+finalise must be **idempotent**, because these cases are all reachable:
+
+| Situation | Required behaviour |
+| --- | --- |
+| Duplicate callbacks race for one Last.fm token | CAS `issued → exchanging`; the loser returns the winner's outcome, never a second `auth.getSession` |
+| State claimed, then `auth.getSession` times out | Bounded retry from `exchanging`; on give-up, fail the handoff and discard any key |
+| Session obtained, job row creation fails | The credential must be written in the same transaction as the row that owns it, or it is unreachable garbage holding write access |
+| Finalise commits `active`, response lost | **Most dangerous case.** The client must not assume failure; it queries handoff status and resumes locally only if the server says the job is not active |
+| Reaper fires during an active upload | Reaping is a CAS from the expected state with a freshness check, never an unconditional delete |
+| Two tabs start handoffs for one username | One live handoff per username; the second is refused with a pointer to the first |
+| Capacity fills between authorisation and activation | Reserve the slot at step 0, not at activation, and release it if the handoff is reaped |
+
+The general rule: **on any uncertain outcome the client stays disabled and asks
+the server**, rather than resuming a local scrobble run that may now be racing a
+live background job.
 6. **Reap abandoned handoffs.** Jobs stuck in `pending_upload`, and unconsumed
    nonces, expire on a timer, deleting any captured credential. A user who closes
    the tab mid-flow must not leave a permanent write credential behind.
@@ -244,25 +291,46 @@ separate server-only API application.)
 
 ### Sessions and identity
 
-**`savas.ca` is a shared origin.** LastWave is served from `savas.ca/lastwave` —
-a path, not a subdomain. Any cookie scoped `Domain=savas.ca` is readable by
-LastWave's JavaScript, and browser security has no way to distinguish the two
-applications. The earlier claim of origin isolation was wrong.
+**`savas.ca` is a shared origin, and no credential scheme can change that.**
+LastWave is served from `savas.ca/lastwave` — a path, not a subdomain. Scrobblify
+and LastWave are the *same web origin*, so the browser has no mechanism that
+distinguishes them.
 
-Accordingly:
+A previous draft tried to engineer around this with a `__Host-` cookie plus an
+SPA-held bearer token. That does not work, and stating why matters more than the
+mitigation did:
 
-- **Use a `__Host-` cookie set on `api.savas.ca`.** `__Host-` forbids the
-  `Domain` attribute, so the cookie is locked to that exact host and is invisible
-  to anything served from `savas.ca`. Attributes: `Secure`, `Path=/`,
-  `SameSite=Lax`, `HttpOnly`.
-- Because the cookie is host-locked, the SPA cannot rely on ambient credentials
-  for cross-site calls; status and control endpoints take an explicit
-  **bearer token issued to the SPA**, with CORS restricted to the exact origin.
-- **All state-changing endpoints require an anti-CSRF token**, since `SameSite=Lax`
-  still permits top-level cross-site GET navigations.
-- Longer term, moving Scrobblify to its own origin is the only way to get real
-  isolation from LastWave. Flagged as an open question because it affects the
-  existing site structure.
+- A `__Host-` cookie on `api.savas.ca` cannot be *read* by `savas.ca` scripts —
+  but cookies are attached by request **destination**, not by initiator. Since
+  `savas.ca` and `api.savas.ca` are same-site, a credentialed `fetch` from
+  LastWave's JavaScript to the API carries the cookie anyway.
+- A bearer token the SPA can read is, by definition, one LastWave can read: same
+  origin, same `localStorage`.
+- CORS restricted "to the exact origin" admits both applications, because it *is*
+  the same origin.
+- Anti-CSRF tokens defend against *cross-site* requests. LastWave is not
+  cross-site.
+
+So the honest choice is binary:
+
+| Option | Consequence |
+| --- | --- |
+| **Dedicated origin** for Scrobblify | Real isolation. `__Host-` cookie on `api.savas.ca` then works as intended. Requires restructuring the existing site. |
+| **Accept a shared trust boundary** | Every script served from `savas.ca` — including LastWave and anything it loads — is inside Scrobblify's security perimeter. An XSS in LastWave is an XSS in Scrobblify. |
+
+**Interim decision: accept the shared trust boundary, and document it.** Both
+applications are written and deployed by the same author, so this is a defensible
+position rather than a third-party exposure — but it must be a *stated* position,
+not an accident, and it means no third-party scripts may be added to `savas.ca`
+without reconsidering it.
+
+Even under that acceptance, keep the mechanisms that defend against everything
+*outside* the origin: `__Host-` cookie on `api.savas.ca` (`Secure`, `Path=/`,
+`SameSite=Lax`, `HttpOnly`), exact-origin CORS, and CSRF tokens on state-changing
+endpoints. They are worth having; they are simply not isolation from LastWave.
+
+Moving to a dedicated origin remains the recommended long-term fix and is a
+blocking open question.
 
 **Fallback:** re-authenticate through Last.fm. The username resolves to the job.
 Works on any device, from any browser, after any cookie loss.
@@ -368,12 +436,30 @@ Last.fm may also **correct** artist/album/track names, flagged by `corrected`.
 Reconciliation must compare against corrected names or it will not find its own
 writes.
 
+### A batch of 50 has 50 outcomes, and a cursor has one
+
+Batching breaks the assumption that progress is a single monotonic index. One
+response can simultaneously contain accepted entries, permanent code 1/2
+rejections, code 5 entries that must be retried later, and — if the response is
+lost — entries whose fate is unknown. Code 5 can begin part-way through a batch,
+so the failures are not even a suffix.
+
+A single `cursor` integer cannot represent that, and advancing it past a mixed
+batch silently drops tracks.
+
+**Therefore:** persist a per-entry outcome (an outcome bitmap or a status column
+keyed by index) for every in-flight batch. The cursor advances only across a
+**contiguous prefix** of entries that are terminal — accepted or permanently
+failed. Unknown and code-5 entries stay behind and are retried or reconciled
+individually. Progress counts and the audit log are derived from the per-entry
+outcomes, not from the cursor.
+
 ### Error handling
 
 | Condition | Response |
 | --- | --- |
 | Error 29 (IP rate limit) | Trip the **global** circuit breaker; back off all jobs. Log with timestamp and active-job count. |
-| `ignoredMessage` code 5 | Per-user daily cap reached. Stop that job until tomorrow; do not treat as failure. |
+| `ignoredMessage` code 5 | Per-user daily cap reached. Stop that job and back off (see below); do not treat as failure. |
 | `ignoredMessage` code 3/4 | Worker timestamp assignment is wrong. Alert; do not silently drop. |
 | `ignoredMessage` code 1/2 | Last.fm rejected the artist/track. Record as permanently failed; never retry. |
 | **Error 9 (invalid session key)** | Credential revoked. Delete it, mark `needs_reauth`, stop. **Never retry.** |
@@ -390,6 +476,20 @@ shared with the public client bundle, so anyone can abuse it and get it
 suspended, killing every background job at once. A **separate, server-only
 Last.fm API application** would isolate that risk, at the cost of an honest
 second authorisation prompt.
+
+### "Wait until tomorrow" is an assumption, not a fact
+
+Code 5 proves the daily cap was reached. It says nothing about *when* it resets:
+whether at midnight in some timezone, or on a rolling 24-hour window. Encoding
+"resume at midnight" into the scheduler risks waking every job at once and
+immediately re-hitting the cap — while also making the thundering herd worse for
+the shared egress IP.
+
+**Until measured:** record the timestamps of accepted sends, wait a conservative
+24 hours from the *first* accepted send of the capped period, and probe with a
+single small batch before resuming full rate. Back off exponentially if the probe
+also returns code 5. The observed reset behaviour is a metric worth capturing in
+the beta precisely because it is currently unknown.
 
 ## Correctness under change
 
@@ -420,20 +520,35 @@ send time keep it; everything else is stamped near the present, spread so that
 every timestamp in a batch is unique.
 
 **What this costs the user.** Their Last.fm history will show these plays at the
-time the import ran, not when they listened. Play counts and top-artist charts
-are correct; the listening *timeline* is fiction. Anyone who values that timeline
-should not use background mode — the foreground path has the same problem for
-re-tagged listens, but over hours rather than weeks.
+time the import ran, not when they listened. **Lifetime play counts stay correct**
+(modulo the duplicates at-least-once permits), but *time-bounded* charts —
+weekly, monthly, yearly — are badly distorted, because the entire import lands in
+whatever weeks the job happened to run. The listening timeline is fiction. Anyone
+who values that timeline should not use background mode; the foreground path has
+the same problem for re-tagged listens, but over hours rather than weeks.
 
-**Ordering is a genuine trade-off, and must be chosen explicitly:**
+**Ordering: send by earliest expiry deadline, not by recency.**
 
-| Order | Effect |
-| --- | --- |
-| Oldest-first | Preserves relative chronology, but tracks near the start of the queue age out of the 14-day window and get restamped anyway. |
-| Recent-first | Maximises the number of tracks keeping their true timestamp; reverses chronology for everything else. |
+An earlier draft chose recent-first "to maximise preserved timestamps". That is
+backwards. A track played today has ~14 days of slack before its timestamp
+becomes unscrobbleable; a track played 13 days ago has one day. Sending recent
+tracks first spends the slack of the tracks that need it least and lets the
+nearly-expired ones expire. This is ordinary earliest-deadline-first scheduling,
+and recency is the wrong key.
 
-**Decision: recent-first**, because it preserves the most genuine data, and
-because the alternative's chronology is itself an artefact of restamping. This
+Two queues, re-evaluated at send time because deadlines move as the job runs:
+
+| Queue | Order | Rationale |
+| --- | --- | --- |
+| Still inside the 14-day window | Earliest expiry first (≈ oldest valid first) | Maximises the number of tracks that keep their true timestamp |
+| Already outside the window | Chronological, so relative order survives | Nothing left to preserve; only ordering is a choice |
+
+**Decision: deadline-first.** For the users this feature targets — large,
+re-tagged, multi-year histories — nearly every track is already outside the
+window at job creation, so the first queue is usually small. That does not make
+the policy unimportant: it is exactly the users with *some* recent listening who
+would notice their genuine timestamps being thrown away needlessly.
+
 must be stated in the opt-in copy, not buried.
 
 ### Duplicate scrobbles: at-least-once, with a narrow reconciliation
@@ -482,8 +597,16 @@ a single API call, not a paginated crawl of the user's history.
 
 ### Safe-deploy mechanics
 
-- **Immutable job payload.** The R2 blob is written once at job creation and
-  never mutated. No code change can alter what an existing job will scrobble.
+- **Immutable job payload — but bytes are not behaviour.** The R2 chunks are
+  written once at job creation and never mutated. That prevents the *data* from
+  changing; it does **not** prevent new code from parsing, normalising, ordering,
+  or timestamping the same bytes differently. Immutability alone is not a
+  deploy-safety guarantee.
+
+  Each job therefore pins an **algorithm version** alongside its manifest
+  version, covering parsing, ordering policy, and timestamp assignment. A worker
+  that encounters a job pinned to semantics it no longer implements must refuse
+  it and flag it, not reinterpret it.
 - **Fencing tokens, not just leases.** A `locked_until` timestamp alone does
   **not** prevent concurrent execution: a tick that stalls past its lease keeps
   running, and its in-flight writes can land after a second tick has claimed the
@@ -500,6 +623,16 @@ a single API call, not a paginated crawl of the user's history.
   This is also what makes a deploy safe mid-batch: the killed tick's lease
   expires, the next tick bumps the generation, and any zombie writes are fenced
   out.
+
+  **Fencing protects D1, not Last.fm.** A superseded tick's *external* request
+  cannot be revoked: worker A sends a batch, its lease expires in flight, worker
+  B takes over and reconciles before A's scrobbles are visible, B resends, then
+  A's request lands too. Fencing rejects A's database writes but not its
+  scrobbles. Mitigate by having a taking-over tick wait at least the maximum
+  outbound request timeout plus a read-visibility grace period before
+  reconciling — and accept that this is exactly the duplicate window the
+  at-least-once decision already acknowledges. It is a reason that decision has to
+  be explicit rather than a claim to have eliminated duplicates.
 - **Additive-only migrations.** Never drop or rename a column a running job
   depends on. Job rows carry a `schema_version` so the worker can handle rows
   created by older code.
@@ -518,10 +651,24 @@ Because this is a beta that may be withdrawn:
   both code paths already exist (`StateManager.exportToFile` /
   `importFromFile`), so this costs almost nothing and guarantees progress is
   never stranded server-side.
-- **Concurrency cap.** Background mode admits a bounded number of concurrent jobs
-  — initially **20**, deliberately below the ~24 capacity ceiling so that status
-  polling and retries retain headroom. When full, the UI offers the normal
-  client-side flow and reports that background mode is at capacity.
+- **Concurrency cap.** Background mode admits a bounded number of concurrent jobs.
+  **The initial number cannot be chosen yet** — the earlier "20, below the ~24
+  ceiling" was derived from the withdrawn capacity model and is void. It must come
+  out of the feasibility spike (see Open questions). When full, the UI offers the
+  normal client-side flow and reports that background mode is at capacity.
+
+  Define explicitly *which states consume a slot*. A job that is `needs_reauth`,
+  `needs_attention`, or paused must not squat a scarce slot for 60 days: attach an
+  inactivity deadline after which it is cancelled, its credential deleted, and the
+  user told.
+
+- **Admission control on job size.** At ~2,700 scrobbles/day, the 60-day
+  credential TTL caps a completable job at roughly **162,000 tracks** — and that
+  assumes no outages, no global pauses, and no code-5 backoff. Reject jobs whose
+  conservative completion estimate exceeds the TTL rather than accepting an import
+  that is guaranteed to be abandoned half-finished. The measured median selection
+  is 34,769, so this affects few users, but those users are precisely the ones
+  most motivated to opt in.
 
 ## Backwards compatibility
 
@@ -638,38 +785,69 @@ New error contexts: `background.handoff`, `background.upload`,
 
 **Blocking — these change the design:**
 
+- **A feasibility spike is a design gate, not a follow-up.** Withdrawing the false
+  ~24-user number was necessary but is not sufficient; "Cloudflare stops being the
+  binding constraint" is currently an assertion, and the 10ms CPU limit was filed
+  as non-blocking despite a tick doing HMAC signing, gzip decompression, JSON
+  parsing, response processing, and reconciliation. **No concurrency cap may be
+  chosen until this is measured.** The spike must state, for one 50-track batch:
+  the exact D1 statements and rows written (including index write amplification),
+  R2 operations, subrequest count, and measured CPU — comparing a
+  **one-mapping-row-per-batch** representation against **fifty**. If the free tier
+  cannot carry even a handful of jobs, that is an argument for starting on Oracle,
+  and it is much cheaper to learn now than after the auth flow is built.
 - **Should Scrobblify move to its own origin?** LastWave shares
-  `https://savas.ca`, so cookie-level isolation between the two is impossible.
-  `__Host-` cookies on `api.savas.ca` mitigate this; a dedicated origin fixes it.
-  Affects existing site structure, so it is the user's call.
+  `https://savas.ca`, and no cookie, token, or CORS configuration can isolate two
+  applications on one origin. Either accept a shared trust boundary explicitly or
+  move. Affects existing site structure, so it is the user's call.
 - **A separate, server-only Last.fm API application?** The public API key can be
   abused by anyone into an error-26 suspension that kills every background job.
   Isolating it costs an extra, honestly-explained authorisation prompt.
-- **D1 write budget on the free tier.** The whole scheduler design assumes cheap
-  per-batch writes (mapping + cursor + audit row, fenced by generation). Measure
-  the actual quota before committing to a tick cadence; if writes are the scarce
-  resource, batch size and audit granularity must be tuned to it, not to
-  subrequest count.
 
 **Non-blocking:**
 
-- Wall-clock and the 10ms CPU limit for scheduled Workers on the free tier, which
-  bound how much pacing and decompression a single tick may do.
+- **Whether Last.fm's daily cap resets on a clock or a rolling window**, which
+  determines the resume schedule after code 5. Measure during the beta.
 - **Whether Last.fm silently deduplicates identical `(artist, track, timestamp)`
   submissions.** Because `reTagOldListens` historically assigned one identical
   timestamp to every listen, a user who played the same track fifty times may
   have been credited with a single scrobble. If confirmed, this is a pre-existing
   client data-loss bug independent of this feature, and the fix — unique
   timestamps — is the same mechanism this design already requires.
+- Concurrent scrobbling from Spotify or another scrobbler consumes the same
+  account budget invisibly. The conflict rules cover Scrobblify's own clients
+  only; nothing can see the rest.
 
 ## Review status
 
-Reviewed adversarially on 2026-07-26. Findings incorporated: batched scrobbling,
-the error-29-vs-ignore-code-5 distinction, the shared-origin cookie flaw, the
-handoff transaction protocol with username binding, fencing tokens, chunked blob
-storage, the withdrawal of the exactly-once and capacity claims, and honest
-framing of timestamp reassignment.
+Reviewed adversarially over two rounds on 2026-07-26.
+
+**Round one** produced: batched scrobbling, the error-29-vs-ignore-code-5
+distinction, the shared-origin cookie flaw, the handoff transaction protocol with
+username binding, fencing tokens, chunked blob storage, withdrawal of the
+exactly-once and capacity claims, and honest framing of timestamp reassignment.
+
+**Round two** corrected the round-one fixes, several of which were wrong:
+
+- Recent-first ordering was **backwards**; it spends slack on the tracks that
+  need it least. Now earliest-deadline-first.
+- The `__Host-` cookie plus bearer token did **not** isolate LastWave — cookies
+  attach by destination, and a token the SPA can read LastWave can read. Replaced
+  with an explicit, documented trust-boundary decision.
+- The handoff had no server-side commit of the digest it later claimed to verify.
+  Added a preflight step and a CAS state machine covering seven ambiguous states.
+- A single cursor cannot represent a 50-entry batch's mixed outcomes.
+- Fencing protects D1 but cannot revoke an in-flight Last.fm request.
+- "Immutable payload" does not make behaviour immutable; jobs now pin an
+  algorithm version.
+- The concurrency cap still referenced the withdrawn ceiling; it is now blocked
+  on a feasibility spike.
 
 Claims verified against Last.fm's published API documentation rather than
 assumed: the 50-scrobble batch limit, the 200-item `getRecentTracks` cap, the
 ASCII signature ordering rule, and the wording of error codes 9, 26, and 29.
+
+**Known unresolved**, carried deliberately rather than papered over: free-tier
+feasibility is unproven pending the spike; the shared origin is a product
+decision; export-before-deletion cannot guarantee delivery; and duplicates remain
+possible by design under at-least-once.

--- a/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
+++ b/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
@@ -33,14 +33,15 @@ All figures filtered to `properties.app = 'scrobblify'`.
 preventive pauses roughly 9:1 — 2,135 `scrobble_rate_limited` events against 190
 `burst_limit` and 40 `daily_limit` pauses.
 
-`BURST_LIMIT` is set too high. The highest `burst_count` ever observed at the
-moment of a rate limit is **849**, below the 950 threshold. The median is 187.
+`BURST_LIMIT` never fires in practice. The highest `burst_count` ever observed at
+the moment of a rate limit is **849**, below the 950 threshold. The median is 187.
 
 **Half of all first rate limits occur at `burst_count = 0`** — before a single
-successful scrobble in the session. Last.fm's limit is a rolling window on the
-account, while `burstCount` and `dailyCount` are in-memory and reset on every
-page load. Users who return after being throttled are immediately throttled
-again.
+successful scrobble in the session. Two causes compound here. `burstCount` and
+`dailyCount` are in-memory and reset on every page load, so users who return
+after being throttled are immediately throttled again. More fundamentally, the
+counters measure the wrong quantity: error 29 is an **IP-level** limit (see
+Scheduler), which no per-session, per-user counter can predict.
 
 **The 1-minute cooldown almost never clears the limit.** Of 2,135 rate limits,
 only 33 produced a `scrobble_rate_limit_recovered`. Where recovery did occur, the
@@ -69,9 +70,13 @@ Two consequences for this design:
 ## Scope
 
 Background mode is offered **only when the number of tracks *remaining* exceeds
-`DAILY_LIMIT` (2,700)** — that is, only to users who would otherwise have to
-return at least once. Smaller imports finish in one sitting and stay entirely
-client-side.
+2,700** — that is, only to users who would otherwise have to return at least
+once. Smaller imports finish in one sitting and stay entirely client-side.
+
+2,700 here is an *eligibility* threshold chosen because it matches the client's
+current `DAILY_LIMIT`, so the offer appears exactly when the client would have
+forced a second visit. It is deliberately **not** reused as a server-side pacing
+constant; see Scheduler for why those constants do not describe reality.
 
 "Remaining" rather than "selected" is deliberate: users already part-way through
 an import must be able to hand off what is left. See Backwards compatibility for
@@ -105,22 +110,52 @@ track-list blobs.
 ### Why Cloudflare, and when to leave
 
 Cloudflare Workers' free tier costs nothing at idle and requires no ops, which
-suits an unproven feature. Its constraints define a hard capacity ceiling:
+suits an unproven feature.
 
-| Constraint | Value | Consequence |
-| --- | --- | --- |
-| Cron ticks/day | 1,440 (1/min) | — |
-| Subrequests per invocation (free) | 50 | ~45 scrobbles/tick after D1/R2 overhead |
-| **Global throughput** | **~65,000 scrobbles/day** | **~24 concurrent users** |
+**Scrobbles are sent in batches of 50.** `track.scrobble` accepts up to 50
+scrobbles per request via array notation (`artist[i]`, `track[i]`,
+`timestamp[i]`). The client sends them one at a time; the worker must not. This
+changes the capacity picture by up to fiftyfold, and Cloudflare stops being the
+binding constraint.
 
-Two things follow. First, ~24 concurrent jobs is the migration trigger: when
-capacity is consistently saturated, move the worker to an Oracle Cloud Always
-Free ARM VM (4 cores, 24GB RAM, 200GB disk, dedicated IP).
+Signing gotcha: Last.fm requires signature parameters sorted by ASCII, so
+`artist[10]` precedes `artist[1]`. JavaScript's default `Array.sort()` already
+produces this order, so `LastFm.getMethodSignature` is correct as written — but
+it is easy to "fix" into being wrong.
 
-Second, 65,000/day averages **0.75 requests/sec**, so the free tier makes it
-impossible to breach Last.fm's documented limit of *5 requests/sec per
-originating IP, averaged over 5 minutes*. Compliance holds by construction, which
-defuses the main concern with Cloudflare's shared egress IPs.
+| Constraint | Value |
+| --- | --- |
+| Cron ticks/day | 1,440 (1/min) |
+| Subrequests per invocation (free) | 50, **including D1 and R2 binding calls** |
+| Free-tier CPU per invocation | 10ms (wall time awaiting `fetch` does not count) |
+| Scrobbles per Last.fm request | 50 |
+
+With batching, the binding constraints become Last.fm's own limits and the D1
+write budget rather than subrequest count. The real ceiling must therefore be
+derived from a proper model — requests, scrobbles, D1 writes, R2 reads, CPU, and
+retries costed separately, at five-minute peaks rather than daily averages —
+before a concurrency cap is chosen. **The previously stated "~24 concurrent
+users" was computed without batching and is withdrawn.**
+
+Two constraints that do *not* relax:
+
+- **Last.fm's 5 requests/sec per originating IP**, averaged over 5 minutes.
+  Batching makes this far easier to satisfy per scrobble, but it must be enforced
+  as a global token bucket, not assumed from a daily average. A daily mean says
+  nothing about a five-minute peak, and Cloudflare's egress IPs are shared with
+  other tenants whose traffic we cannot see.
+- **The per-user daily scrobble limit**, which is unchanged by batching.
+
+**Migration trigger:** move to an Oracle Cloud Always Free ARM VM (4 cores, 24GB
+RAM, 200GB disk, dedicated IP) when either the D1 write budget or the shared
+egress IP becomes the limiting factor.
+
+### Blob storage must be chunked
+
+A single gzipped NDJSON blob cannot be randomly accessed at a cursor. Fetching
+and decompressing the whole thing every tick, for every job, will exhaust both
+CPU and memory. Store **independently compressed chunks plus a manifest**, sized
+so a tick reads exactly the chunk its cursor points into.
 
 ### Portability requirements
 
@@ -160,12 +195,40 @@ fresh token for its own independent session key.
 
 **The client's session key is never transmitted anywhere.** Because the user has
 already authorised the application, Last.fm does not re-prompt; the user sees a
-redirect, not a second login. After successful handoff the SPA clears its own
-session key from `localStorage` — the background job now owns the import.
+redirect, not a second login.
 
-The worker then encrypts the session key, creates the job row, sets an httpOnly
-cookie, and redirects back to the SPA, which uploads the selected track list as
-gzipped NDJSON to R2.
+#### The handoff is a transaction, and must be written as one
+
+A full-page redirect destroys all in-memory state. The user's selection lives
+only in Vuex (`SelectStep.vue:504-511`) and is **not** persisted, so a naive
+"redirect, come back, upload" flow loses the very data the job needs. Worse, the
+ordering below is easy to get wrong in ways that either strand a credential or
+lose an import.
+
+Required protocol:
+
+1. **Persist before leaving.** The SPA writes the selected track list to
+   `localStorage`/IndexedDB *before* redirecting, together with a
+   `pending_handoff` record holding a nonce, the expected Last.fm username, and a
+   SHA-256 digest of the serialised list.
+2. **Bind the nonce.** The `cb=` URL carries a worker-signed, single-use,
+   short-TTL nonce. The worker rejects any callback whose nonce is unknown,
+   expired, or already consumed.
+3. **Verify the account.** `auth.getSession` returns a username. If it does not
+   match the username bound to the nonce, **abort and discard the session key.**
+   Without this check a user logged into a second Last.fm account in another tab
+   — or an attacker who lands their own callback — has one account's history
+   written into another's. This is the single most damaging failure mode in the
+   design.
+4. **Upload, then finalise.** The job is created in `pending_upload`. The SPA
+   uploads the blob; the worker verifies the digest matches the one committed in
+   step 1, then transitions the job to `active`.
+5. **Clear last.** The SPA clears its own session key and cached list only after
+   the worker confirms `active`. Clearing first turns any upload failure into
+   total data loss.
+6. **Reap abandoned handoffs.** Jobs stuck in `pending_upload`, and unconsumed
+   nonces, expire on a timer, deleting any captured credential. A user who closes
+   the tab mid-flow must not leave a permanent write credential behind.
 
 ### The shared secret stays public
 
@@ -176,23 +239,38 @@ majority of users who never use background mode.
 
 This design keeps client-side auth as the default, so **the shared secret remains
 public**. This is the existing accepted risk and is not made worse. The API key is
-public regardless.
+public regardless. (See error 26 under Scheduler for the case in favour of a
+separate server-only API application.)
 
 ### Sessions and identity
 
-- **httpOnly cookie**, scoped `Domain=savas.ca; SameSite=Lax; Secure`. Because
-  `savas.ca` and `api.savas.ca` share a registrable domain, this is a
-  first-party cookie and survives Safari's ITP and Firefox's Total Cookie
-  Protection. This is why the API must not live on `*.workers.dev`.
-  (`savas.ca` is already served by Cloudflare nameservers, so a Workers custom
-  domain is the only setup required.)
-- **Fallback:** re-authenticate through Last.fm. The username resolves to the
-  job. Works on any device, from any browser, after any cookie loss.
+**`savas.ca` is a shared origin.** LastWave is served from `savas.ca/lastwave` —
+a path, not a subdomain. Any cookie scoped `Domain=savas.ca` is readable by
+LastWave's JavaScript, and browser security has no way to distinguish the two
+applications. The earlier claim of origin isolation was wrong.
 
-  This exchange necessarily yields *another* session key. It is used only to
-  prove identity and **must be discarded immediately, never stored**. The job
-  continues to use the credential captured at handoff. Storing a second
-  credential per user would widen the blast radius for no benefit.
+Accordingly:
+
+- **Use a `__Host-` cookie set on `api.savas.ca`.** `__Host-` forbids the
+  `Domain` attribute, so the cookie is locked to that exact host and is invisible
+  to anything served from `savas.ca`. Attributes: `Secure`, `Path=/`,
+  `SameSite=Lax`, `HttpOnly`.
+- Because the cookie is host-locked, the SPA cannot rely on ambient credentials
+  for cross-site calls; status and control endpoints take an explicit
+  **bearer token issued to the SPA**, with CORS restricted to the exact origin.
+- **All state-changing endpoints require an anti-CSRF token**, since `SameSite=Lax`
+  still permits top-level cross-site GET navigations.
+- Longer term, moving Scrobblify to its own origin is the only way to get real
+  isolation from LastWave. Flagged as an open question because it affects the
+  existing site structure.
+
+**Fallback:** re-authenticate through Last.fm. The username resolves to the job.
+Works on any device, from any browser, after any cookie loss.
+
+This exchange necessarily yields *another* session key. It is used only to prove
+identity and **must be discarded immediately, never stored**. The job continues to
+use the credential captured at handoff. Storing a second credential per user would
+widen the blast radius for no benefit.
 
 No email address, no password, no PII beyond the Last.fm username.
 
@@ -206,10 +284,17 @@ do not control:
   D1 alongside the ciphertext.
 - **Delete it the instant** the job completes, fails permanently, is cancelled,
   or reaches its TTL of 60 days.
-- Delete the R2 blob at the same time. Retain only summary statistics.
+- Delete the R2 blob at the same time. Retain summary statistics and the failed-
+  track list the completion page promises — nothing else. (An earlier draft said
+  "summary statistics only", which contradicted that promise.)
 - **Expose no generic Last.fm proxy.** The worker may only scrobble tracks
-  already committed to that job's immutable blob. A stolen cookie therefore
-  grants nothing beyond reading progress.
+  already committed to that job's immutable blob.
+
+**Honest statement of stolen-cookie impact.** A stolen session does not merely
+leak progress: it can cancel a job, and — depending on which controls exist — pause
+or restart one. It cannot scrobble arbitrary tracks, which is the property the
+"no generic proxy" rule buys. The `__Host-` cookie plus CSRF tokens above exist
+specifically because the shared `savas.ca` origin makes theft plausible.
 
 ## Progress and status
 
@@ -241,35 +326,80 @@ failure list, rather than "no job found".
 `last_run_at` ascending and each gets a slice of the tick's budget. FIFO would
 let a single 100k import starve every job behind it for a month.
 
-**Per-user limits reuse the existing constants.** `BURST_LIMIT` (950, 10-minute
-cooldown) and `DAILY_LIMIT` (2,700) currently live in `ScrobbleStep.vue:88-89`,
-and `LastFm.isRateLimitError` / `isNetworkError` in `src/api/LastFm.ts`. These
-move into a `shared/` module imported by both the SPA and the worker. Divergence
-between client and server pacing would be a slow-to-surface bug.
+### Two different limits, previously conflated
+
+Last.fm's documentation makes a distinction the client does not:
+
+- **Error 29** is *"Rate limit exceeded — Your **IP** has made too many requests
+  in a short period."* It is an IP-level throttle, not a per-user one.
+- **The per-user daily scrobble cap** is not an error at all. It arrives as a
+  *successful* HTTP response carrying `ignoredMessage` **code 5, "Daily scrobble
+  limit exceeded"**.
+
+The client treats error 29 as if it were a per-user scrobble limit, which is why
+`BURST_LIMIT`/`DAILY_LIMIT` correlate so poorly with observed throttling and why
+half of all first rate limits occur at `burst_count = 0`. An IP-level limit is
+not something a per-session counter can predict.
+
+Consequences for the worker:
+
+- A global circuit breaker on error 29 is **correct**, because the limit really
+  is shared across every job on that egress IP. Per-job backoff alone would not
+  help.
+- Per-user pacing must be driven by `ignoredMessage` code 5, not by error 29.
+- **Do not port `BURST_LIMIT = 950` or `DAILY_LIMIT = 2,700` to the worker.**
+  Measured data shows they do not describe reality. Share
+  `LastFm.isRateLimitError`, `isNetworkError`, and the ignore-code taxonomy via a
+  `shared/` module; derive pacing from observed responses instead of guessed
+  constants.
+
+### A 200 response does not mean the scrobble was stored
+
+`track.scrobble` reports per-track rejections in `ignoredMessage` while returning
+HTTP success. Parsing it is a **correctness invariant**, not an optimisation: the
+cursor may only advance for entries Last.fm actually accepted.
+
+The relevant codes are 1 (artist ignored), 2 (track ignored), 3 (timestamp too
+old), 4 (timestamp too new), and 5 (daily limit). Code 3 and 4 indicate the
+worker's own timestamp assignment is wrong and should be treated as a bug signal,
+not a per-track failure. Code 5 means stop scrobbling for that user today.
+
+Last.fm may also **correct** artist/album/track names, flagged by `corrected`.
+Reconciliation must compare against corrected names or it will not find its own
+writes.
 
 ### Error handling
 
 | Condition | Response |
 | --- | --- |
-| Error 29 (rate limit) | Exponential backoff for the job **and** trip a global circuit breaker — on shared egress, a 29 may mean the whole IP is throttled. Log every occurrence with timestamp and active-job count. |
-| **Error 9 (invalid session key)** | The user revoked access. Delete the credential immediately, mark the job `needs_reauth`, stop. **Never retry.** |
-| Network error | Backoff and retry; the track was not consumed. |
-| Per-track failure | Record and continue, matching current client behaviour. |
+| Error 29 (IP rate limit) | Trip the **global** circuit breaker; back off all jobs. Log with timestamp and active-job count. |
+| `ignoredMessage` code 5 | Per-user daily cap reached. Stop that job until tomorrow; do not treat as failure. |
+| `ignoredMessage` code 3/4 | Worker timestamp assignment is wrong. Alert; do not silently drop. |
+| `ignoredMessage` code 1/2 | Last.fm rejected the artist/track. Record as permanently failed; never retry. |
+| **Error 9 (invalid session key)** | Credential revoked. Delete it, mark `needs_reauth`, stop. **Never retry.** |
+| **Error 26 (suspended API key)** | Every job is dead until resolved. Halt globally and alert; retrying makes it worse. |
+| Network error | Backoff and retry; nothing was consumed. |
 | 10 consecutive failures | Pause the job, mark `needs_attention`, surface on the status page. |
 
-Error 9 is new. The client never encounters it because its session key is created
-seconds before use; a job running for weeks certainly will.
+Error 9 is not exclusive to long-running jobs — the client persists session keys
+in `localStorage` indefinitely and can hit revocation too — but the worker must
+handle it without a user present to re-authenticate.
 
-The error-29 log is also the dataset that answers whether Last.fm's binding limit
-is per-API-key or per-IP — currently unknown, and the deciding factor in whether
-migrating to a dedicated IP would help at all.
+Error 26 is a single point of failure worth stating plainly: the API key is
+shared with the public client bundle, so anyone can abuse it and get it
+suspended, killing every background job at once. A **separate, server-only
+Last.fm API application** would isolate that risk, at the cost of an honest
+second authorisation prompt.
 
 ## Correctness under change
 
 Jobs run for weeks, so bugs **will** be fixed while jobs are in flight. The
 design must make that safe.
 
-### Timestamps are assigned by the worker, not the client
+### Timestamp reassignment rewrites history — say so plainly
+
+This is a product decision, not an implementation detail, and it deserves an
+honest statement rather than a reassuring one.
 
 Two facts make client-assigned timestamps unusable for a long-running job.
 
@@ -277,29 +407,49 @@ Two facts make client-assigned timestamps unusable for a long-running job.
 single `reTagDate`, and `scrobblify.ts:263-270` assigns that same `Date` instance
 to every listen. Users with more than two weeks of history — the overwhelming
 majority, and the only users offered background mode — therefore submit tens of
-thousands of scrobbles carrying an identical millisecond timestamp.
+thousands of scrobbles carrying an identical millisecond timestamp. (A fix for
+this is in flight client-side; the worker must not depend on either version.)
 
 **A 37-day job outlives Last.fm's 14-day window.** Any timestamp fixed at job
 creation is rejected from roughly day 15 onward.
 
 Therefore the job blob stores artist, track, and album, plus the original listen
 date only as metadata. **The worker assigns the actual scrobble timestamp at send
-time**, spreading a batch across the preceding minute so every track in it is
-unique. Tracks whose original timestamp still falls inside the 14-day window at
-send time keep it; everything else is stamped to the present.
+time.** Tracks whose original timestamp still falls inside the 14-day window at
+send time keep it; everything else is stamped near the present, spread so that
+every timestamp in a batch is unique.
 
-A visible consequence worth stating in the beta copy: a background import spreads
-re-tagged listens across the whole run rather than landing them all on one day.
-This is more plausible than the current behaviour, not less.
+**What this costs the user.** Their Last.fm history will show these plays at the
+time the import ran, not when they listened. Play counts and top-artist charts
+are correct; the listening *timeline* is fiction. Anyone who values that timeline
+should not use background mode — the foreground path has the same problem for
+re-tagged listens, but over hours rather than weeks.
 
-### Duplicate scrobbles: persist the timestamp, then reconcile on it
+**Ordering is a genuine trade-off, and must be chosen explicitly:**
+
+| Order | Effect |
+| --- | --- |
+| Oldest-first | Preserves relative chronology, but tracks near the start of the queue age out of the 14-day window and get restamped anyway. |
+| Recent-first | Maximises the number of tracks keeping their true timestamp; reverses chronology for everything else. |
+
+**Decision: recent-first**, because it preserves the most genuine data, and
+because the alternative's chronology is itself an artefact of restamping. This
+must be stated in the opt-in copy, not buried.
+
+### Duplicate scrobbles: at-least-once, with a narrow reconciliation
 
 **The ambiguity window is irreducible.** Even committing the cursor after every
 single track, the worker can crash between Last.fm accepting a scrobble and D1
-recording it. No cursor granularity eliminates this.
+recording it. No cursor granularity eliminates this. **This design does not
+achieve exactly-once**, and should not claim to.
 
-Reconciling against the *user's* timestamps cannot resolve it, for the reasons
-above. Reconciling against *ours* can:
+The choice is between at-least-once (risk duplicates) and at-most-once (risk
+silently dropped tracks). **Choose at-least-once**: a duplicate is visible and
+removable by the user; a missing track is invisible and unrecoverable.
+
+Reconciliation narrows the window but does not close it. Reconciling against the
+*user's* timestamps cannot work at all, for the reasons above. Reconciling against
+*ours* can:
 
 1. Before sending a batch, durably write its index→assigned-timestamp mapping to
    D1.
@@ -309,13 +459,23 @@ above. Reconciling against *ours* can:
 Because the worker chose those timestamps and they are unique by construction,
 the mapping is a stable idempotency key that survives a crash. On recovery, the
 next tick fetches the narrow window covering the uncommitted mapping via
-`getAllScrobblesInRange` and checks for those exact `(artist, track, timestamp)`
-tuples. Present means done; absent means safe to send. Last.fm's own
-deduplication is not relied upon.
+`getAllScrobblesInRange` and looks for those exact tuples.
 
-An **unclean tick** is precisely: a job whose `locked_until` lease expired without
-the tick having committed a final cursor. The next tick to pick up that job
-reconciles before scrobbling anything.
+Known limits of that check, which is why the guarantee is at-least-once:
+
+- Last.fm **normalises and corrects** artist/track names, so comparison must be
+  fuzzy or must use the `corrected` names returned by the scrobble call itself.
+- `from`/`to` on `user.getRecentTracks` are strictly exclusive; the window must be
+  widened by a second on each side.
+- There is **no read-after-write guarantee**; a scrobble accepted moments ago may
+  not yet appear.
+- `user.getRecentTracks` caps `limit` at **200**. Note `LastFm.ts:168` currently
+  sets `PAGE_SIZE = 1000`, which is invalid — a pre-existing bug to fix if this
+  code is shared.
+
+An **unclean tick** is precisely: a job whose lease expired without the tick
+having committed a final cursor. The next tick to pick up that job reconciles
+before scrobbling anything.
 
 Because the reconciliation window is one batch wide — under a minute — this costs
 a single API call, not a paginated crawl of the user's history.
@@ -324,10 +484,22 @@ a single API call, not a paginated crawl of the user's history.
 
 - **Immutable job payload.** The R2 blob is written once at job creation and
   never mutated. No code change can alter what an existing job will scrobble.
-- **Lease-based locking.** Each job carries a `locked_until` timestamp. Two ticks
-  can never process one job concurrently, and a tick killed mid-batch by a deploy
-  simply has its lease expire; the next tick resumes from the last committed
-  cursor and reconciles.
+- **Fencing tokens, not just leases.** A `locked_until` timestamp alone does
+  **not** prevent concurrent execution: a tick that stalls past its lease keeps
+  running, and its in-flight writes can land after a second tick has claimed the
+  job. Leases are a liveness hint, not mutual exclusion.
+
+  Each job therefore carries a monotonically increasing `generation`. Acquiring a
+  job is a single atomic compare-and-set that bumps it
+  (`UPDATE ... SET generation = generation + 1, locked_until = ? WHERE id = ? AND
+  locked_until < now`). Every subsequent write by that tick — timestamp mapping,
+  cursor commit, audit row — carries its generation and is conditioned on it still
+  being current. A superseded tick's writes are rejected rather than silently
+  interleaved.
+
+  This is also what makes a deploy safe mid-batch: the killed tick's lease
+  expires, the next tick bumps the generation, and any zombie writes are fenced
+  out.
 - **Additive-only migrations.** Never drop or rename a column a running job
   depends on. Job rows carry a `schema_version` so the worker can handle rows
   created by older code.
@@ -464,14 +636,40 @@ New error contexts: `background.handoff`, `background.upload`,
 
 ## Open questions for implementation
 
-- Whether D1 and R2 binding calls count against the 50-subrequest limit. This
-  determines the achievable batch size and therefore the exact capacity ceiling.
-  It does not affect correctness, because reconciliation is required regardless.
-- Wall-clock limits for scheduled Workers on the free tier, which bound how long
-  a single tick may pace its batch.
+**Blocking — these change the design:**
+
+- **Should Scrobblify move to its own origin?** LastWave shares
+  `https://savas.ca`, so cookie-level isolation between the two is impossible.
+  `__Host-` cookies on `api.savas.ca` mitigate this; a dedicated origin fixes it.
+  Affects existing site structure, so it is the user's call.
+- **A separate, server-only Last.fm API application?** The public API key can be
+  abused by anyone into an error-26 suspension that kills every background job.
+  Isolating it costs an extra, honestly-explained authorisation prompt.
+- **D1 write budget on the free tier.** The whole scheduler design assumes cheap
+  per-batch writes (mapping + cursor + audit row, fenced by generation). Measure
+  the actual quota before committing to a tick cadence; if writes are the scarce
+  resource, batch size and audit granularity must be tuned to it, not to
+  subrequest count.
+
+**Non-blocking:**
+
+- Wall-clock and the 10ms CPU limit for scheduled Workers on the free tier, which
+  bound how much pacing and decompression a single tick may do.
 - **Whether Last.fm silently deduplicates identical `(artist, track, timestamp)`
-  submissions.** Because `reTagOldListens` currently assigns one identical
-  timestamp to every listen, a user who played the same track fifty times may be
-  credited with a single scrobble today. If confirmed, this is a pre-existing
-  data-loss bug in the client, independent of this feature, and the fix — unique
+  submissions.** Because `reTagOldListens` historically assigned one identical
+  timestamp to every listen, a user who played the same track fifty times may
+  have been credited with a single scrobble. If confirmed, this is a pre-existing
+  client data-loss bug independent of this feature, and the fix — unique
   timestamps — is the same mechanism this design already requires.
+
+## Review status
+
+Reviewed adversarially on 2026-07-26. Findings incorporated: batched scrobbling,
+the error-29-vs-ignore-code-5 distinction, the shared-origin cookie flaw, the
+handoff transaction protocol with username binding, fencing tokens, chunked blob
+storage, the withdrawal of the exactly-once and capacity claims, and honest
+framing of timestamp reassignment.
+
+Claims verified against Last.fm's published API documentation rather than
+assumed: the 50-scrobble batch limit, the 200-item `getRecentTracks` cap, the
+ASCII signature ordering rule, and the wording of error codes 9, 26, and 29.

--- a/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
+++ b/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
@@ -16,6 +16,48 @@ does not make it unnecessary. Most users with large histories never finish.
 This design adds an opt-in beta backend that continues a user's import while
 their browser is closed.
 
+## Measured baseline (PostHog, 2026-07-09 to 2026-07-26)
+
+All figures filtered to `properties.app = 'scrobblify'`.
+
+| Metric | Value |
+| --- | --- |
+| People who started scrobbling | 63 |
+| People who hit a Last.fm rate limit | 33 |
+| Of those, people who completed | 7 |
+| Median tracks selected (rate-limited users) | 34,769 |
+| Median tracks actually scrobbled | 745 |
+| **Median share of import completed** | **2.1%** |
+
+**The preventive pause is not working.** Reactive rate limits outnumber
+preventive pauses roughly 9:1 — 2,135 `scrobble_rate_limited` events against 190
+`burst_limit` and 40 `daily_limit` pauses.
+
+`BURST_LIMIT` is set too high. The highest `burst_count` ever observed at the
+moment of a rate limit is **849**, below the 950 threshold. The median is 187.
+
+**Half of all first rate limits occur at `burst_count = 0`** — before a single
+successful scrobble in the session. Last.fm's limit is a rolling window on the
+account, while `burstCount` and `dailyCount` are in-memory and reset on every
+page load. Users who return after being throttled are immediately throttled
+again.
+
+**The 1-minute cooldown almost never clears the limit.** Of 2,135 rate limits,
+only 33 produced a `scrobble_rate_limit_recovered`. Where recovery did occur, the
+median elapsed time was **130 minutes**. Median actual pause duration is exactly
+the configured 60 seconds, so this is not timer throttling — the cooldown is
+simply two orders of magnitude too short, and recovery happens by accident when a
+user walks away.
+
+Two consequences for this design:
+
+1. The worker must not reuse the client's cooldown or threshold values. It needs
+   backoff on the order of hours, and limit counters persisted per user rather
+   than per session.
+2. **Fixing the client's cooldown and thresholds is a cheaper, higher-value
+   change than this feature, and should ship first.** It benefits all users
+   immediately and de-risks the backend by establishing real limit values.
+
 ## Non-goals
 
 - **Making imports faster.** The 2,700/day per-user limit is imposed by Last.fm
@@ -223,30 +265,56 @@ migrating to a dedicated IP would help at all.
 Jobs run for weeks, so bugs **will** be fixed while jobs are in flight. The
 design must make that safe.
 
-### Duplicate scrobbles: reconcile, don't prevent
+### Timestamps are assigned by the worker, not the client
+
+Two facts make client-assigned timestamps unusable for a long-running job.
+
+**Re-tagged listens all share one timestamp.** `UploadStep.vue:173` creates a
+single `reTagDate`, and `scrobblify.ts:263-270` assigns that same `Date` instance
+to every listen. Users with more than two weeks of history — the overwhelming
+majority, and the only users offered background mode — therefore submit tens of
+thousands of scrobbles carrying an identical millisecond timestamp.
+
+**A 37-day job outlives Last.fm's 14-day window.** Any timestamp fixed at job
+creation is rejected from roughly day 15 onward.
+
+Therefore the job blob stores artist, track, and album, plus the original listen
+date only as metadata. **The worker assigns the actual scrobble timestamp at send
+time**, spreading a batch across the preceding minute so every track in it is
+unique. Tracks whose original timestamp still falls inside the 14-day window at
+send time keep it; everything else is stamped to the present.
+
+A visible consequence worth stating in the beta copy: a background import spreads
+re-tagged listens across the whole run rather than landing them all on one day.
+This is more plausible than the current behaviour, not less.
+
+### Duplicate scrobbles: persist the timestamp, then reconcile on it
 
 **The ambiguity window is irreducible.** Even committing the cursor after every
 single track, the worker can crash between Last.fm accepting a scrobble and D1
 recording it. No cursor granularity eliminates this.
 
-Therefore the worker **reconciles against Last.fm** using the existing
-`getAllScrobblesInRange`, fetching the user's actual recent scrobbles and
-skipping any already present. The duplicate-detection logic in the upload step
-already performs this comparison.
+Reconciling against the *user's* timestamps cannot resolve it, for the reasons
+above. Reconciling against *ours* can:
 
-An **unclean tick** is precisely: a job whose `locked_until` lease expired
-without the tick having committed a final cursor. The next tick to pick up that
-job reconciles before scrobbling anything.
+1. Before sending a batch, durably write its index→assigned-timestamp mapping to
+   D1.
+2. Send the batch.
+3. Commit the cursor.
 
-The **reconciliation range** runs from the timestamp of the earliest track in the
-uncommitted cursor range to the present. Tracks found already on the user's
-profile are marked complete and skipped; the cursor advances past them.
+Because the worker chose those timestamps and they are unique by construction,
+the mapping is a stable idempotency key that survives a crash. On recovery, the
+next tick fetches the narrow window covering the uncommitted mapping via
+`getAllScrobblesInRange` and checks for those exact `(artist, track, timestamp)`
+tuples. Present means done; absent means safe to send. Last.fm's own
+deduplication is not relied upon.
 
-Once reconciliation exists, batch size is purely a throughput tuning knob rather
-than a safety mechanism. Last.fm's own deduplication is not relied upon.
+An **unclean tick** is precisely: a job whose `locked_until` lease expired without
+the tick having committed a final cursor. The next tick to pick up that job
+reconciles before scrobbling anything.
 
-Re-tagged listens carry today's timestamp, so they fall inside the reconciliation
-window like any other recent scrobble.
+Because the reconciliation window is one batch wide — under a minute — this costs
+a single API call, not a paginated crawl of the user's history.
 
 ### Safe-deploy mechanics
 
@@ -308,3 +376,9 @@ New error contexts: `background.handoff`, `background.upload`,
   It does not affect correctness, because reconciliation is required regardless.
 - Wall-clock limits for scheduled Workers on the free tier, which bound how long
   a single tick may pace its batch.
+- **Whether Last.fm silently deduplicates identical `(artist, track, timestamp)`
+  submissions.** Because `reTagOldListens` currently assigns one identical
+  timestamp to every listen, a user who played the same track fifty times may be
+  credited with a single scrobble today. If confirmed, this is a pre-existing
+  data-loss bug in the client, independent of this feature, and the fix — unique
+  timestamps — is the same mechanism this design already requires.

--- a/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
+++ b/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
@@ -68,10 +68,14 @@ Two consequences for this design:
 
 ## Scope
 
-Background mode is offered **only when the selected track count exceeds
+Background mode is offered **only when the number of tracks *remaining* exceeds
 `DAILY_LIMIT` (2,700)** — that is, only to users who would otherwise have to
 return at least once. Smaller imports finish in one sitting and stay entirely
 client-side.
+
+"Remaining" rather than "selected" is deliberate: users already part-way through
+an import must be able to hand off what is left. See Backwards compatibility for
+the four entry points where the offer appears.
 
 It is an **opt-in beta**. Users must actively choose it, and the UI must label it
 as beta.
@@ -347,13 +351,97 @@ Because this is a beta that may be withdrawn:
   polling and retries retain headroom. When full, the UI offers the normal
   client-side flow and reports that background mode is at capacity.
 
+## Backwards compatibility
+
+The feature must not strand anyone already part-way through an import, and must
+not break the existing client-side flow in either direction.
+
+### Entry points
+
+Background mode is offered wherever the *remaining* track count exceeds 2,700 —
+not only on fresh imports:
+
+1. **New import**, at step 3→4 after selection.
+2. **Resume from saved IndexedDB state**, via `restoreFromState`
+   (`Scrobblify.vue:154-173`), which already computes the remaining set.
+3. **Import of a progress JSON file**, which flows through the same
+   `restoreFromState` path.
+4. **Mid-scrobble, on the step 4 pause screen** — particularly when paused for
+   `daily_limit` or `rate_limit`.
+
+Entry point 4 matters most. Telemetry shows users abandon precisely at those
+pauses, so that screen is where "let us finish this for you" belongs. The offer
+must be available while paused, not only at the start of a run.
+
+### Handing off partial progress
+
+The job payload is the **remaining** tracks, exactly as `restoreFromState`
+already derives them. Already-scrobbled tracks are never re-sent, so the
+timestamps the client previously used are irrelevant to the job.
+
+Two rules make the transition safe:
+
+- **The handoff is atomic from the client's perspective.** Local state is cleared
+  only after the server has confirmed both job creation and blob storage. A
+  failure at any earlier point leaves local state untouched and the user
+  continues client-side, none the wiser.
+- **The client must halt its scrobble loop on successful handoff.** If both the
+  browser tab and the worker hold the same remaining track list, both will
+  scrobble it. This is the single most likely source of duplicates in the whole
+  design, and it is entirely self-inflicted.
+
+### Tolerating old and new state files
+
+`StateManager.importFromFile` requires only `totalTracks`, `completedIndices`,
+`failedIndices`, and `tracks`, defaulting everything else. Handoff must depend on
+nothing beyond that set — in particular it must not require `userName`, which
+older files lack. The Last.fm username comes from the auth handoff itself.
+
+Any field this feature adds to `ScrobbleState` **must be optional**, so that old
+files still import into new clients and new files still import into older cached
+clients.
+
+### Falling back to the client
+
+The export escape hatch must emit exactly the `ScrobbleState` shape
+`importFromFile` accepts, so a user can always return to the client-side flow.
+Ordering matters on cancellation: **generate and deliver the export before
+deleting the R2 blob**, or the data needed to build it is already gone.
+
+### Conflict rules
+
+- A live background job and local saved state must never both be active for one
+  user. On detecting both, the UI presents the background job as authoritative
+  and offers to discard the local state.
+- The client-side scrobble loop must refuse to start while a live background job
+  exists for the authenticated user.
+
 ## Beta framing
 
-- Opt-in only, presented at step 3→4 when the selection exceeds 2,700 tracks.
+- Opt-in only, offered at any of the four entry points above when the remaining
+  selection exceeds 2,700 tracks.
 - Labelled clearly as beta in the UI.
 - The opt-in must state plainly: the selected track list is uploaded to
   Scrobblify's server; a Last.fm credential is stored until the import finishes;
   access can be revoked at any time at last.fm/settings/applications.
+
+### Reporting bugs
+
+Because this is a beta running unattended for weeks, users need a direct channel
+when something looks wrong — there is no support system, and a silently stalled
+job is indistinguishable from a slow one.
+
+Both the opt-in dialog and the status view carry a feedback link to
+**niko@savas.ca**, following the prefilled-mailto pattern already established in
+`ErrorDialog.vue:52-68`: a fixed subject and a body pre-populated with context.
+
+The body should include the **job ID**, so a report is traceable to a specific
+job without asking the user to describe their state. The job ID is an opaque
+identifier and not personal data; analytics already identifies users by
+`lastfm_username` regardless.
+
+The link must remain reachable on a *failed* or *stalled* job, not only a healthy
+one. That is the case where it will actually be used.
 
 ## Analytics
 
@@ -365,6 +453,11 @@ New events: `background_offered`, `background_opted_in`, `background_declined`,
 `background_handoff_failed`, `background_job_created`,
 `background_job_completed`, `background_job_cancelled`, `background_reauth_needed`,
 `background_capacity_full`.
+
+`background_offered` and `background_opted_in` carry an `entry_point` property
+(`new_import`, `resume_saved`, `resume_file`, `paused`) so the four entry points
+can be compared. If the paused-screen offer is where users actually convert, that
+is worth knowing early.
 
 New error contexts: `background.handoff`, `background.upload`,
 `background.status`, `worker.scrobbleBatch`, `worker.reconcile`.

--- a/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
+++ b/docs/superpowers/specs/2026-07-26-background-scrobbling-design.md
@@ -1,0 +1,310 @@
+# Background Scrobbling (Beta) — Design
+
+**Date:** 2026-07-26
+**Status:** Approved, pending implementation plan
+
+## Problem
+
+Last.fm enforces an undocumented daily scrobble limit of roughly 2,800 per user.
+Scrobblify paces itself at 2,700/day (`ScrobbleStep.vue:89`) and pauses when it
+hits that ceiling. A user importing a 100,000-track Spotify history must
+therefore return to the site once a day for about 37 consecutive days.
+
+Save-and-resume (`src/services/StateManager.ts`) makes returning painless, but it
+does not make it unnecessary. Most users with large histories never finish.
+
+This design adds an opt-in beta backend that continues a user's import while
+their browser is closed.
+
+## Non-goals
+
+- **Making imports faster.** The 2,700/day per-user limit is imposed by Last.fm
+  and applies equally to a backend. A 100k import still takes ~37 days. The
+  feature buys *unattendedness*, not speed.
+- **User accounts.** The Last.fm username is the only identity.
+- **Replacing the client-side flow.** It remains the default for most users.
+
+## Scope
+
+Background mode is offered **only when the selected track count exceeds
+`DAILY_LIMIT` (2,700)** — that is, only to users who would otherwise have to
+return at least once. Smaller imports finish in one sitting and stay entirely
+client-side.
+
+It is an **opt-in beta**. Users must actively choose it, and the UI must label it
+as beta.
+
+## Architecture
+
+Three components.
+
+**1. The SPA** (unchanged deployment: FTP to Namecheap via `.github/workflows/cd.yml`)
+
+Parses the Spotify ZIP, deduplicates, and lets the user select tracks — all in
+the browser, exactly as today. The Spotify ZIP never leaves the browser under
+any circumstance.
+
+**2. API worker** (Cloudflare Worker, HTTP, at `api.savas.ca`)
+
+Handles the Last.fm auth callback, job creation, track-list upload, and status
+queries.
+
+**3. Scheduler worker** (Cloudflare Worker, Cron Trigger, every minute)
+
+Selects due jobs, scrobbles a batch for each, commits progress.
+
+**Storage:** D1 for job rows, cursors, and encrypted session keys. R2 for
+track-list blobs.
+
+### Why Cloudflare, and when to leave
+
+Cloudflare Workers' free tier costs nothing at idle and requires no ops, which
+suits an unproven feature. Its constraints define a hard capacity ceiling:
+
+| Constraint | Value | Consequence |
+| --- | --- | --- |
+| Cron ticks/day | 1,440 (1/min) | — |
+| Subrequests per invocation (free) | 50 | ~45 scrobbles/tick after D1/R2 overhead |
+| **Global throughput** | **~65,000 scrobbles/day** | **~24 concurrent users** |
+
+Two things follow. First, ~24 concurrent jobs is the migration trigger: when
+capacity is consistently saturated, move the worker to an Oracle Cloud Always
+Free ARM VM (4 cores, 24GB RAM, 200GB disk, dedicated IP).
+
+Second, 65,000/day averages **0.75 requests/sec**, so the free tier makes it
+impossible to breach Last.fm's documented limit of *5 requests/sec per
+originating IP, averaged over 5 minutes*. Compliance holds by construction, which
+defuses the main concern with Cloudflare's shared egress IPs.
+
+### Portability requirements
+
+The worker must be movable to a plain VM without a rewrite:
+
+- Plain `fetch` and WebCrypto only in the scrobbling core. Both exist in Workers
+  and Node 18+. No `node:` imports, no Workers-only APIs.
+- Portable SQL only, so D1's SQLite can be swapped for Postgres.
+- R2 access behind a minimal get/put-by-key interface, so it can become S3 or
+  the filesystem.
+- **No Durable Objects for scheduling.** This is the principal lock-in trap.
+  Scheduling stays "SELECT due jobs → process batch → commit", which runs
+  identically under Workers Cron, a systemd timer, or pg_cron.
+
+## Authentication
+
+### The constraint
+
+Last.fm issues exactly one credential: the session key returned by
+`auth.getSession`. It never expires, it is unscoped write access, and it can only
+be revoked by the user at last.fm/settings/applications. There is no scoped or
+delegated variant.
+
+The server must therefore hold a permanent write credential. The design cannot
+avoid this; it can only minimise how long the credential is held and how much
+damage its disclosure would cause.
+
+### Handoff via a second Last.fm round-trip
+
+The wizard authenticates at step 1, before the track count is known
+(`Scrobblify.vue:28-36`). By the time we can offer background mode (step 3→4),
+the browser already holds a session key.
+
+When the user opts in, the SPA redirects to Last.fm auth again with `cb=`
+pointing at **the API worker** rather than the SPA. The worker exchanges the
+fresh token for its own independent session key.
+
+**The client's session key is never transmitted anywhere.** Because the user has
+already authorised the application, Last.fm does not re-prompt; the user sees a
+redirect, not a second login. After successful handoff the SPA clears its own
+session key from `localStorage` — the background job now owns the import.
+
+The worker then encrypts the session key, creates the job row, sets an httpOnly
+cookie, and redirects back to the SPA, which uploads the selected track list as
+gzipped NDJSON to R2.
+
+### The shared secret stays public
+
+`store.ts:12` hardcodes both the Last.fm API key and shared secret in the client
+bundle. Routing *all* authentication through the worker would make the secret
+genuinely secret, but it would put Cloudflare on the critical path for the
+majority of users who never use background mode.
+
+This design keeps client-side auth as the default, so **the shared secret remains
+public**. This is the existing accepted risk and is not made worse. The API key is
+public regardless.
+
+### Sessions and identity
+
+- **httpOnly cookie**, scoped `Domain=savas.ca; SameSite=Lax; Secure`. Because
+  `savas.ca` and `api.savas.ca` share a registrable domain, this is a
+  first-party cookie and survives Safari's ITP and Firefox's Total Cookie
+  Protection. This is why the API must not live on `*.workers.dev`.
+  (`savas.ca` is already served by Cloudflare nameservers, so a Workers custom
+  domain is the only setup required.)
+- **Fallback:** re-authenticate through Last.fm. The username resolves to the
+  job. Works on any device, from any browser, after any cookie loss.
+
+  This exchange necessarily yields *another* session key. It is used only to
+  prove identity and **must be discarded immediately, never stored**. The job
+  continues to use the credential captured at handoff. Storing a second
+  credential per user would widen the blast radius for no benefit.
+
+No email address, no password, no PII beyond the Last.fm username.
+
+### Credential lifecycle
+
+Non-negotiable, because a free-tier account that is suspended or reclaimed would
+otherwise strand other people's permanent write credentials on infrastructure we
+do not control:
+
+- Encrypt the session key at rest with a key held as a Worker secret, never in
+  D1 alongside the ciphertext.
+- **Delete it the instant** the job completes, fails permanently, is cancelled,
+  or reaches its TTL of 60 days.
+- Delete the R2 blob at the same time. Retain only summary statistics.
+- **Expose no generic Last.fm proxy.** The worker may only scrobble tracks
+  already committed to that job's immutable blob. A stolen cookie therefore
+  grants nothing beyond reading progress.
+
+## Progress and status
+
+`Scrobblify.vue` already checks `hasSavedState()` on mount and renders a "Resume
+previous session?" alert. Background jobs reuse that pattern: a parallel
+`GET /api/job` renders a banner for a live job, opening a status view in place of
+step 4's local scrobbler.
+
+The status view shows completed/total, current state (running, waiting on the
+daily limit, rate-limited, needs re-auth, failed), failed-track count, and an
+**estimated completion date**. The estimate is essential: without "expect to
+finish around 1 September", a user watching a 37-day job will conclude it is
+broken and re-import.
+
+Controls: pause, cancel-and-delete-my-data, export progress (see Escape hatches),
+and a link to last.fm/settings/applications.
+
+Polling is a fetch on load plus a 60-second poll while the tab is visible. The
+100,000/day invocation budget is shared with the scheduler, and a job advancing
+at 2,700/day does not warrant more.
+
+Completed job rows are retained (without the session key) for 30 days so a
+returning user sees "done — 94,203 scrobbled, 112 failed" with a downloadable
+failure list, rather than "no job found".
+
+## Scheduler
+
+**Fairness is round-robin, not FIFO.** Due jobs are selected ordered by
+`last_run_at` ascending and each gets a slice of the tick's budget. FIFO would
+let a single 100k import starve every job behind it for a month.
+
+**Per-user limits reuse the existing constants.** `BURST_LIMIT` (950, 10-minute
+cooldown) and `DAILY_LIMIT` (2,700) currently live in `ScrobbleStep.vue:88-89`,
+and `LastFm.isRateLimitError` / `isNetworkError` in `src/api/LastFm.ts`. These
+move into a `shared/` module imported by both the SPA and the worker. Divergence
+between client and server pacing would be a slow-to-surface bug.
+
+### Error handling
+
+| Condition | Response |
+| --- | --- |
+| Error 29 (rate limit) | Exponential backoff for the job **and** trip a global circuit breaker — on shared egress, a 29 may mean the whole IP is throttled. Log every occurrence with timestamp and active-job count. |
+| **Error 9 (invalid session key)** | The user revoked access. Delete the credential immediately, mark the job `needs_reauth`, stop. **Never retry.** |
+| Network error | Backoff and retry; the track was not consumed. |
+| Per-track failure | Record and continue, matching current client behaviour. |
+| 10 consecutive failures | Pause the job, mark `needs_attention`, surface on the status page. |
+
+Error 9 is new. The client never encounters it because its session key is created
+seconds before use; a job running for weeks certainly will.
+
+The error-29 log is also the dataset that answers whether Last.fm's binding limit
+is per-API-key or per-IP — currently unknown, and the deciding factor in whether
+migrating to a dedicated IP would help at all.
+
+## Correctness under change
+
+Jobs run for weeks, so bugs **will** be fixed while jobs are in flight. The
+design must make that safe.
+
+### Duplicate scrobbles: reconcile, don't prevent
+
+**The ambiguity window is irreducible.** Even committing the cursor after every
+single track, the worker can crash between Last.fm accepting a scrobble and D1
+recording it. No cursor granularity eliminates this.
+
+Therefore the worker **reconciles against Last.fm** using the existing
+`getAllScrobblesInRange`, fetching the user's actual recent scrobbles and
+skipping any already present. The duplicate-detection logic in the upload step
+already performs this comparison.
+
+An **unclean tick** is precisely: a job whose `locked_until` lease expired
+without the tick having committed a final cursor. The next tick to pick up that
+job reconciles before scrobbling anything.
+
+The **reconciliation range** runs from the timestamp of the earliest track in the
+uncommitted cursor range to the present. Tracks found already on the user's
+profile are marked complete and skipped; the cursor advances past them.
+
+Once reconciliation exists, batch size is purely a throughput tuning knob rather
+than a safety mechanism. Last.fm's own deduplication is not relied upon.
+
+Re-tagged listens carry today's timestamp, so they fall inside the reconciliation
+window like any other recent scrobble.
+
+### Safe-deploy mechanics
+
+- **Immutable job payload.** The R2 blob is written once at job creation and
+  never mutated. No code change can alter what an existing job will scrobble.
+- **Lease-based locking.** Each job carries a `locked_until` timestamp. Two ticks
+  can never process one job concurrently, and a tick killed mid-batch by a deploy
+  simply has its lease expire; the next tick resumes from the last committed
+  cursor and reconciles.
+- **Additive-only migrations.** Never drop or rename a column a running job
+  depends on. Job rows carry a `schema_version` so the worker can handle rows
+  created by older code.
+- **Global kill switch.** A `paused` flag in D1, checked first on every tick. If
+  a bug is spotted, flip it, jobs freeze safely mid-flight, fix, unflip.
+- **Batch audit log.** Every batch records job ID, cursor range, timestamp, and
+  outcome, so any incident can be diagnosed and its blast radius established.
+
+### Escape hatches
+
+Because this is a beta that may be withdrawn:
+
+- The status page can **export progress in the existing `StateManager` JSON
+  format**. A user whose job is cancelled — or whose beta access ends — imports
+  that file and resumes client-side through the existing flow. The format and
+  both code paths already exist (`StateManager.exportToFile` /
+  `importFromFile`), so this costs almost nothing and guarantees progress is
+  never stranded server-side.
+- **Concurrency cap.** Background mode admits a bounded number of concurrent jobs
+  — initially **20**, deliberately below the ~24 capacity ceiling so that status
+  polling and retries retain headroom. When full, the UI offers the normal
+  client-side flow and reports that background mode is at capacity.
+
+## Beta framing
+
+- Opt-in only, presented at step 3→4 when the selection exceeds 2,700 tracks.
+- Labelled clearly as beta in the UI.
+- The opt-in must state plainly: the selected track list is uploaded to
+  Scrobblify's server; a Last.fm credential is stored until the import finishes;
+  access can be revoked at any time at last.fm/settings/applications.
+
+## Analytics
+
+Follow the conventions in `AGENTS.md` — use the helpers in
+`src/services/Analytics.ts`, never `posthog` directly, and never widen an error
+message to include raw request parameters.
+
+New events: `background_offered`, `background_opted_in`, `background_declined`,
+`background_handoff_failed`, `background_job_created`,
+`background_job_completed`, `background_job_cancelled`, `background_reauth_needed`,
+`background_capacity_full`.
+
+New error contexts: `background.handoff`, `background.upload`,
+`background.status`, `worker.scrobbleBatch`, `worker.reconcile`.
+
+## Open questions for implementation
+
+- Whether D1 and R2 binding calls count against the 50-subrequest limit. This
+  determines the achievable batch size and therefore the exact capacity ceiling.
+  It does not affect correctness, because reconciliation is required regardless.
+- Wall-clock limits for scheduled Workers on the free tier, which bound how long
+  a single tick may pace its batch.

--- a/src/api/LastFm.ts
+++ b/src/api/LastFm.ts
@@ -1,6 +1,15 @@
 import Scrobble from '@/models/Scrobble';
 import md5 from 'blueimp-md5';
 
+/** Outcome of a single track.scrobble call, as reported by Last.fm itself. */
+export interface ScrobbleResult {
+  accepted: number;
+  ignored: number;
+  /** 0 when accepted. See LastFm.describeIgnoreCode for the rest. */
+  ignoredCode: number;
+  ignoredMessage: string;
+}
+
 export default class LastFm {
   private API_BASE_URL = 'https://ws.audioscrobbler.com/2.0/';
 
@@ -244,21 +253,66 @@ export default class LastFm {
   }
 
   // https://www.last.fm/api/show/track.scrobble
-  public async scrobblePlay(play: Scrobble): Promise<void> {
+  public async scrobblePlay(play: Scrobble, timestampSecOverride?: number): Promise<ScrobbleResult> {
     if (!this.userAuthKey) {
       throw new Error('Not authenticated.');
     }
+    const timestampSec = timestampSecOverride !== undefined
+      ? timestampSecOverride
+      : Math.floor(play.timestamp.getTime() / 1000);
     const params: {[key: string]: string} = {
       method: 'track.scrobble',
       'artist[0]': play.artist,
       'track[0]': play.track,
-      'timestamp[0]': Math.floor(play.timestamp.getTime() / 1000).toString(),
+      'timestamp[0]': timestampSec.toString(),
     };
     // Add album if available
     if (play.album) {
       params['album[0]'] = play.album;
     }
-    await this.makeRequest('POST', params, true);
+    const response = await this.makeRequest('POST', params, true);
+    return LastFm.parseScrobbleResponse(response);
+  }
+
+  /**
+   * A 200 from track.scrobble does not mean the play was stored. Last.fm
+   * reports per-scrobble rejections in `ignoredMessage`, which this client used
+   * to discard entirely — so expired timestamps and daily-limit rejections were
+   * counted as successes.
+   *
+   * Defaults to "accepted" whenever the shape is unrecognised: an unparseable
+   * response must never turn a working scrobble into a reported failure.
+   */
+  private static parseScrobbleResponse(response: any): ScrobbleResult {
+    const attr = (response && response.scrobbles && response.scrobbles['@attr']) || {};
+    let entry = response && response.scrobbles && response.scrobbles.scrobble;
+    if (Array.isArray(entry)) {
+      [entry] = entry;
+    }
+    const ignoredMessage = (entry && entry.ignoredMessage) || {};
+
+    const accepted = Number(attr.accepted);
+    const ignored = Number(attr.ignored);
+    const code = Number(ignoredMessage.code);
+
+    return {
+      accepted: Number.isFinite(accepted) ? accepted : 1,
+      ignored: Number.isFinite(ignored) ? ignored : 0,
+      ignoredCode: Number.isFinite(code) ? code : 0,
+      ignoredMessage: ignoredMessage['#text'] || '',
+    };
+  }
+
+  /** https://www.last.fm/api/show/track.scrobble — ignoredMessage codes. */
+  public static describeIgnoreCode(code: number, message: string): string {
+    const known: {[key: number]: string} = {
+      1: 'Last.fm ignored this artist',
+      2: 'Last.fm ignored this track',
+      3: 'Timestamp was too far in the past (Last.fm only accepts the last 14 days)',
+      4: 'Timestamp was in the future',
+      5: 'Daily scrobble limit reached',
+    };
+    return known[code] || message || `Last.fm ignored this scrobble (code ${code})`;
   }
 
   private async makeRequest(

--- a/src/components/ScrobbleStep.vue
+++ b/src/components/ScrobbleStep.vue
@@ -6,6 +6,10 @@
         {{ tracksToScrobble.length }} tracks ready to scrobble.
         Please review them and then click Scrobble to begin.
       </p>
+      <p v-if="isResumed" class="overall-progress">
+        Resuming: {{ previouslyScrobbled }} of {{ originalTotalTracks }} already scrobbled in
+        earlier sessions.
+      </p>
       <div class="final-list">
         <span v-for="(track, i) in tracksToScrobble" :key="i">
           {{ track.track }} - {{ track.artist }} @ {{ track.timestamp.toString() }}<br>
@@ -20,9 +24,15 @@
       <v-progress-linear v-model="progress" class="mb-4"></v-progress-linear>
 
       <v-card class="pa-3 mb-4" outlined>
-        <div>Scrobbled {{ scrobbledTracks }} of {{ tracksToScrobble.length }} ({{ failedTracks.length }} failed)</div>
-        <div>Burst: {{ burstCount }} / 950</div>
-        <div>Today: {{ dailyCount }} / ~2,700</div>
+        <div class="overall-progress">
+          Overall: {{ totalSucceeded }} of {{ originalTotalTracks }} scrobbled
+        </div>
+        <div>
+          This session: {{ scrobbledTracks }} of {{ tracksToScrobble.length }}
+          ({{ failedTracks.length }} failed)
+        </div>
+        <div>Recent: {{ burstCount }} / {{ burstLimit }} in the last 10 minutes</div>
+        <div>Last 24h: {{ dailyCount }} / {{ dailyLimit }}</div>
       </v-card>
 
       <v-btn outlined @click="manualPause">Pause &amp; Save</v-btn>
@@ -30,7 +40,7 @@
 
     <!-- Paused view -->
     <div v-else-if="paused">
-      <v-alert type="warning" prominent>
+      <v-alert :type="stopped ? 'error' : 'warning'" prominent>
         {{ pauseReason }}
       </v-alert>
 
@@ -41,17 +51,27 @@
         <div v-if="countdown > 0" class="mb-2 text-body-2">
           You can save progress and leave now, then resume later at any time.
         </div>
-        <div class="mb-3">{{ scrobbledTracks }} of {{ tracksToScrobble.length }} completed so far</div>
+        <div v-if="stopped && autoSaved" class="mb-2 text-body-2">
+          Your progress has been saved automatically — just come back to this page later
+          and choose "Resume".
+        </div>
+        <div class="mb-3 overall-progress">
+          {{ totalSucceeded }} of {{ originalTotalTracks }} completed so far
+        </div>
 
         <v-btn class="primary mr-2" @click="saveAndExit">Save Progress &amp; Leave</v-btn>
-        <v-btn outlined disabled>Wait Here</v-btn>
+        <v-btn v-if="stopped" outlined @click="scrobble">Try Again Now</v-btn>
+        <v-btn v-else outlined disabled>Wait Here</v-btn>
       </v-card>
     </div>
 
     <!-- Completed view -->
     <div v-else-if="completed">
       <v-alert type="success">
-        Scrobbling complete! {{ scrobbledTracks }} of {{ tracksToScrobble.length }} tracks scrobbled.
+        Scrobbling complete!
+        <span class="overall-progress">
+          {{ totalSucceeded }} of {{ originalTotalTracks }} tracks scrobbled.
+        </span>
       </v-alert>
     </div>
 
@@ -77,6 +97,9 @@
   text-align: left;
   margin-top: 20px;
 }
+.overall-progress {
+  font-weight: 500;
+}
 </style>
 <script lang="ts">
 import Vue from 'vue';
@@ -84,16 +107,61 @@ import Scrobble from '@/models/Scrobble';
 import LastFm from '@/api/LastFm';
 import ErrorDialog from '@/components/ErrorDialog.vue';
 import { trackEvent, trackError } from '@/services/Analytics';
+import RateLimitTracker, { DAILY_LIMIT } from '@/services/RateLimitTracker';
 
-const BURST_LIMIT = 950;
-const DAILY_LIMIT = 2700;
-const MS_PER_MINUTE = 60 * 1000;
-const BURST_COOLDOWN_MS = 10 * MS_PER_MINUTE;
-const RATE_LIMIT_COOLDOWN_MS = 1 * MS_PER_MINUTE;
-const RATE_LIMIT_COOLDOWN_MINUTES = RATE_LIMIT_COOLDOWN_MS / MS_PER_MINUTE;
-const RATE_LIMIT_COOLDOWN_SECONDS = Math.ceil(RATE_LIMIT_COOLDOWN_MS / 1000);
-const NETWORK_ERROR_COOLDOWN_MS = 30 * 1000;
-const NETWORK_ERROR_COOLDOWN_SECONDS = Math.ceil(NETWORK_ERROR_COOLDOWN_MS / 1000);
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+
+// Escalating backoff between retries of a rate-limited track.
+//
+// The old behaviour was a flat 1-minute retry, forever. Across 2,135 observed
+// rate limits it produced only 33 recoveries, and where recovery did happen the
+// median elapsed time was 130 minutes — i.e. it effectively never worked, it
+// just kept the user staring at a countdown. Two users sat through 200+
+// consecutive retries.
+const RATE_LIMIT_BACKOFF_MS = [
+  5 * MS_PER_MINUTE,
+  15 * MS_PER_MINUTE,
+  30 * MS_PER_MINUTE,
+];
+
+// After the ladder above is exhausted (~50 minutes) we stop retrying, save the
+// user's progress and tell them to come back later. Nobody watches a browser
+// tab for two hours; an honest "come back later" beats an infinite countdown.
+const MAX_RATE_LIMIT_RETRIES = RATE_LIMIT_BACKOFF_MS.length;
+
+const NETWORK_ERROR_COOLDOWN_MS = 30 * MS_PER_SECOND;
+const NETWORK_ERROR_COOLDOWN_SECONDS = Math.ceil(NETWORK_ERROR_COOLDOWN_MS / MS_PER_SECOND);
+
+const MAX_CONSECUTIVE_FAILURES = 10;
+
+// Re-tagged plays (see Scrobble.reTagged) are stamped at send time, starting
+// this far back and stepping forward one second per scrobble. Last.fm rejects
+// timestamps in the future and anything older than 14 days, so the cursor is
+// always clamped into (now - 6h, now].
+//
+// Six hours of runway is far more than the pacing needs — the burst limit keeps
+// sustained throughput below one scrobble per second — but it keeps every
+// scrobble comfortably inside the window no matter how long the import runs or
+// how many times it is resumed.
+const RETAG_BACKFILL_SECONDS = 6 * 60 * 60;
+
+// Last.fm ignoredMessage code 5: the account is out of scrobbles for the day.
+// Retrying is pointless until tomorrow.
+const IGNORE_CODE_DAILY_LIMIT = 5;
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.round(ms / MS_PER_MINUTE);
+  if (totalMinutes < 1) {
+    const seconds = Math.max(1, Math.ceil(ms / MS_PER_SECOND));
+    return `${seconds} second${seconds === 1 ? '' : 's'}`;
+  }
+  if (totalMinutes < 60) {
+    return `${totalMinutes} minute${totalMinutes === 1 ? '' : 's'}`;
+  }
+  const hours = Math.round(totalMinutes / 60);
+  return `${hours} hour${hours === 1 ? '' : 's'}`;
+}
 
 export default Vue.extend({
   components: { 'error-dialog': ErrorDialog },
@@ -101,13 +169,28 @@ export default Vue.extend({
     return {
       scrobbling: false,
       currentTrackName: '',
+      // Tracks *processed* this session (successes + permanent failures). Also
+      // the loop index / resume point, so it must count both.
       scrobbledTracks: 0,
+      // Tracks Last.fm actually accepted this session.
+      succeededTracks: 0,
+      // High-water mark of the send-time timestamp allocator for re-tagged
+      // plays. Persisted so a resume cannot reuse an earlier run's seconds.
+      reTagCursorSec: 0,
       paused: false,
+      // A pause the loop will not resume from on its own. Distinguishes "wait a
+      // moment" from "we've given up for now, come back later".
+      stopped: false,
+      autoSaved: false,
       pauseReason: '',
       countdown: 0,
       countdownTimer: null as number | null,
+      // Mirrors of RateLimitTracker state. The tracker itself is deliberately
+      // non-reactive (see created()), so these are refreshed explicitly.
       burstCount: 0,
       dailyCount: 0,
+      burstLimit: 0,
+      dailyLimit: DAILY_LIMIT,
       rateLimitPauseCount: 0,
       firstRateLimitAtMs: null as number | null,
       failedTracks: [] as Array<{ track: Scrobble; error: string }>,
@@ -121,6 +204,29 @@ export default Vue.extend({
     tracksToScrobble(): Scrobble[] {
       return this.$store.state.selectedScrobbles;
     },
+    /**
+     * Tracks completed in an earlier session that is being resumed. The store
+     * only ever holds the *remaining* tracks, so this is the only signal that
+     * distinguishes a resume from a fresh start.
+     */
+    previouslyScrobbled(): number {
+      return this.$store.state.resumedScrobbleCount || 0;
+    },
+    isResumed(): boolean {
+      return this.previouslyScrobbled > 0;
+    },
+    /**
+     * Size of the whole import. `tracksToScrobble.length` shrinks every time a
+     * session is saved and resumed, so it is useless as a completion
+     * denominator — this does not shrink.
+     */
+    originalTotalTracks(): number {
+      return this.$store.state.originalTotalTracks || this.tracksToScrobble.length;
+    },
+    /** Successful scrobbles across every session of this import. */
+    totalSucceeded(): number {
+      return this.previouslyScrobbled + this.succeededTracks;
+    },
     progress(): number {
       return (100 * this.scrobbledTracks) / this.tracksToScrobble.length;
     },
@@ -130,6 +236,9 @@ export default Vue.extend({
       return `${minutes}:${seconds.toString().padStart(2, '0')}`;
     },
   },
+  created() {
+    this.syncRateLimitCounters();
+  },
   beforeDestroy() {
     if (this.countdownTimer) {
       clearInterval(this.countdownTimer);
@@ -137,21 +246,95 @@ export default Vue.extend({
     }
   },
   methods: {
+    /**
+     * The rolling-window rate-limit tracker, created lazily and cached
+     * off-reactivity (`_`-prefixed keys are skipped by Vue 2's observer). It is
+     * keyed by Last.fm username, which is not reliably known until the user
+     * actually reaches this step.
+     */
+    rateLimitTracker(): RateLimitTracker {
+      const api = this.$store.state.lfmApi as LastFm;
+      const userName = api.getUserName();
+      const self = this as any;
+      if (!self._rateLimitTracker || self._rateLimitTrackerUser !== userName) {
+        self._rateLimitTracker = new RateLimitTracker(userName);
+        self._rateLimitTrackerUser = userName;
+      }
+      return self._rateLimitTracker as RateLimitTracker;
+    },
+
+    syncRateLimitCounters() {
+      const tracker = this.rateLimitTracker();
+      this.burstCount = tracker.burstCount;
+      this.dailyCount = tracker.dailyCount;
+      this.burstLimit = tracker.burstLimit;
+    },
+
+    /**
+     * Progress properties attached to every scrobble analytics event.
+     *
+     * The session-scoped fields (`scrobbled_tracks` / `total_tracks`) only
+     * describe the current chunk of work: after a resume the store holds just
+     * the remaining tracks, so `total_tracks` shrinks and a percentage built
+     * from those two is measured against a moving denominator. The
+     * `original_*` / `total_succeeded` fields are stable across resumes and are
+     * what completion rate should be computed from.
+     */
+    progressProps(extra: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        scrobbled_tracks: this.scrobbledTracks,
+        total_tracks: this.tracksToScrobble.length,
+        succeeded_tracks: this.succeededTracks,
+        failed_tracks: this.failedTracks.length,
+        is_resumed: this.isResumed,
+        previously_scrobbled: this.previouslyScrobbled,
+        original_total_tracks: this.originalTotalTracks,
+        total_succeeded: this.totalSucceeded,
+        completion_pct: this.originalTotalTracks
+          ? Math.round((1000 * this.totalSucceeded) / this.originalTotalTracks) / 10
+          : 0,
+        ...extra,
+      };
+    },
+
     async scrobble() {
+      const tracker = this.rateLimitTracker();
       this.scrobbling = true;
       this.completed = false;
+      this.paused = false;
+      this.stopped = false;
+      this.autoSaved = false;
+      this.pauseReason = '';
+      // A manual retry after giving up starts a fresh backoff ladder.
+      this.rateLimitPauseCount = 0;
+      this.firstRateLimitAtMs = null;
+      this.syncRateLimitCounters();
+
       const api = this.$store.state.lfmApi as LastFm;
       const tracks = this.tracksToScrobble;
       let consecutiveFailures = 0;
-      const MAX_CONSECUTIVE_FAILURES = 10;
+      // Re-based on every entry into the loop (including resumes and manual
+      // retries), which is what keeps re-tagged plays inside Last.fm's 14-day
+      // window however long a user leaves an import sitting.
+      //
+      // It must never step back onto a second an earlier run already used:
+      // Last.fm silently discards a repeat of (artist, track, timestamp) while
+      // still reporting it as accepted, so a collision would lose a play with
+      // no error to detect. Hence the carried-forward high-water mark.
+      let reTagCursorSec = Math.max(
+        this.reTagCursorSec,
+        (this.$store.state.reTagCursorSec as number) || 0,
+      );
+      // Held across retries of the current track; cleared only once the track
+      // is finally consumed. See the allocation site below.
+      let pendingReTagTimestampSec: number | undefined;
 
-      if (this.scrobbledTracks === 0) {
-        trackEvent('scrobble_started', { total_tracks: tracks.length });
+      if (this.scrobbledTracks === 0 && this.previouslyScrobbled === 0) {
+        trackEvent('scrobble_started', this.progressProps());
       } else {
-        trackEvent('scrobble_resumed', {
-          total_tracks: tracks.length,
+        trackEvent('scrobble_resumed', this.progressProps({
           already_scrobbled: this.scrobbledTracks,
-        });
+        }));
       }
 
       // `i` is incremented conditionally at the end so a rate-limited track can be retried.
@@ -161,19 +344,37 @@ export default Vue.extend({
           return;
         }
 
-        // Check burst limit
-        if (this.burstCount >= BURST_LIMIT) {
-          this.pauseReason = 'Approaching Last.fm\'s burst limit (~1,000 scrobbles). Pausing for 10 minutes to avoid being rate-limited.';
-          trackEvent('scrobble_paused', { reason: 'burst_limit', scrobbled_tracks: this.scrobbledTracks, total_tracks: tracks.length });
-          await this.pauseWithCountdown(BURST_COOLDOWN_MS);
-          this.burstCount = 0;
+        // Preventive pacing: wait until the rolling burst window has room.
+        // Unlike the old fixed counter this survives page reloads, so a user
+        // who returns after being throttled no longer spends a budget they
+        // don't have.
+        const burstWaitMs = tracker.msUntilBurstSafe();
+        if (burstWaitMs > 0) {
+          this.pauseReason = `Pacing to stay under Last.fm's rate limit — ${tracker.burstCount} scrobbles sent in the last 10 minutes. Resuming automatically.`;
+          trackEvent('scrobble_paused', this.progressProps({
+            reason: 'burst_limit',
+            burst_count: tracker.burstCount,
+            burst_limit: tracker.burstLimit,
+            wait_ms: burstWaitMs,
+          }));
+          await this.pauseWithCountdown(burstWaitMs);
+          this.syncRateLimitCounters();
         }
 
-        // Check daily limit
-        if (this.dailyCount >= DAILY_LIMIT) {
-          this.pauseReason = 'Approaching Last.fm\'s daily limit (~2,800 scrobbles). You\'ll need to come back tomorrow to continue.';
-          trackEvent('scrobble_paused', { reason: 'daily_limit', scrobbled_tracks: this.scrobbledTracks, total_tracks: tracks.length });
+        // Daily ceiling: a rolling 24h window, so it frees up gradually rather
+        // than all at once at midnight. There is nothing useful to wait for in
+        // the tab, so save and stop.
+        const dailyWaitMs = tracker.msUntilDailySafe();
+        if (dailyWaitMs > 0) {
+          this.pauseReason = `You've reached Last.fm's daily limit of about ${DAILY_LIMIT} scrobbles. Come back in ${formatDuration(dailyWaitMs)} to continue where you left off.`;
+          trackEvent('scrobble_paused', this.progressProps({
+            reason: 'daily_limit',
+            daily_count: tracker.dailyCount,
+            wait_ms: dailyWaitMs,
+          }));
+          this.stopped = true;
           this.paused = true;
+          this.autoSave();
           return;
         }
 
@@ -184,11 +385,57 @@ export default Vue.extend({
         let recoveredFromRateLimit = false;
         let elapsedSinceFirstRateLimitMs = 0;
         let recoveredRateLimitPauseCount = 0;
+
+        // Allocated once per track, not once per attempt. A retry must re-send
+        // the *identical* (artist, track, timestamp) tuple: if the original
+        // request actually reached Last.fm and only the response was lost, an
+        // identical resend is silently deduplicated, whereas a fresh second
+        // would be stored as a second, phantom play.
+        if (track.reTagged && pendingReTagTimestampSec === undefined) {
+          const nowSec = Math.floor(Date.now() / MS_PER_SECOND);
+          const earliestSec = nowSec - RETAG_BACKFILL_SECONDS;
+          reTagCursorSec = Math.min(nowSec, Math.max(reTagCursorSec + 1, earliestSec));
+          this.reTagCursorSec = reTagCursorSec;
+          pendingReTagTimestampSec = reTagCursorSec;
+        }
+
         try {
-          await api.scrobblePlay(track);
-          this.$store.commit('trackScrobbled');
-          this.burstCount++;
-          this.dailyCount++;
+          const result = await api.scrobblePlay(track, pendingReTagTimestampSec);
+          // The request succeeded but Last.fm may still have thrown the play
+          // away. Counting that as success is what made the completion numbers
+          // untrustworthy.
+          tracker.recordSend();
+          this.syncRateLimitCounters();
+
+          if (result.ignored > 0) {
+            trackEvent('scrobble_ignored', this.progressProps({
+              track_index: i,
+              ignored_code: result.ignoredCode,
+              re_tagged: !!track.reTagged,
+            }));
+
+            if (result.ignoredCode === IGNORE_CODE_DAILY_LIMIT) {
+              // Not this track's fault and not permanent, so it must stay in
+              // the queue *unprocessed*. Recording it as failed here would
+              // count it once now and again when the resume re-sends it.
+              this.pauseReason = 'Last.fm says you have hit your daily scrobble limit. Your progress is saved — come back tomorrow and resume.';
+              trackEvent('scrobble_paused', this.progressProps({ reason: 'lastfm_daily_limit' }));
+              this.stopped = true;
+              this.paused = true;
+              this.autoSave();
+              return;
+            }
+
+            const reason = LastFm.describeIgnoreCode(result.ignoredCode, result.ignoredMessage);
+            this.$store.commit('trackFailed');
+            this.failedTracks.push({ track, error: reason });
+            consecutiveFailures++;
+          } else {
+            this.$store.commit('trackScrobbled');
+            this.succeededTracks += 1;
+            consecutiveFailures = 0;
+          }
+
           if (this.firstRateLimitAtMs !== null) {
             recoveredFromRateLimit = true;
             elapsedSinceFirstRateLimitMs = Date.now() - this.firstRateLimitAtMs;
@@ -196,53 +443,84 @@ export default Vue.extend({
             this.firstRateLimitAtMs = null;
             this.rateLimitPauseCount = 0;
           }
-          consecutiveFailures = 0;
+
+          if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            this.errorMessage = `${MAX_CONSECUTIVE_FAILURES} scrobbles in a row were rejected by Last.fm. Your progress is saved.`;
+            this.errorDetails = this.failedTracks[this.failedTracks.length - 1].error;
+            this.showError = true;
+            this.pauseReason = 'Paused because Last.fm rejected several scrobbles in a row.';
+            this.paused = true;
+            // These were permanent rejections, so the tracks are genuinely
+            // processed — advance past this one before saving so the resume
+            // doesn't re-send and re-count it.
+            this.scrobbledTracks += 1;
+            this.autoSave();
+            return;
+          }
         } catch (e) {
-          // Rate limit (Last.fm error 29 / HTTP 429): pause and retry the same track
-          // rather than counting it as a failure.
+          // Rate limit (Last.fm error 29 / HTTP 429): back off and retry the
+          // same track rather than counting it as a failure.
           if (LastFm.isRateLimitError(e)) {
             const rateLimitStartMs = Date.now();
             if (this.firstRateLimitAtMs === null) {
               this.firstRateLimitAtMs = rateLimitStartMs;
             }
             this.rateLimitPauseCount++;
-            const pauseDurationLabel = RATE_LIMIT_COOLDOWN_MS % MS_PER_MINUTE === 0
-              ? `${RATE_LIMIT_COOLDOWN_MINUTES} ${RATE_LIMIT_COOLDOWN_MINUTES === 1 ? 'minute' : 'minutes'}`
-              : `${RATE_LIMIT_COOLDOWN_SECONDS} ${RATE_LIMIT_COOLDOWN_SECONDS === 1 ? 'second' : 'seconds'}`;
-            this.pauseReason = `Rate limited by Last.fm. Pausing for ${pauseDurationLabel} before retrying.`;
-            trackEvent('scrobble_paused', { reason: 'rate_limit', scrobbled_tracks: this.scrobbledTracks, total_tracks: tracks.length });
-            trackEvent('scrobble_rate_limited', {
-              scrobbled_tracks: this.scrobbledTracks,
-              total_tracks: tracks.length,
+            // Teach the tracker where this account's real ceiling is.
+            tracker.recordRateLimit();
+            this.syncRateLimitCounters();
+
+            trackEvent('scrobble_rate_limited', this.progressProps({
               track_index: i,
-              burst_count: this.burstCount,
-              daily_count: this.dailyCount,
+              burst_count: tracker.burstCount,
+              burst_limit: tracker.burstLimit,
+              daily_count: tracker.dailyCount,
               rate_limit_pause_count: this.rateLimitPauseCount,
               elapsed_since_first_rate_limit_ms: rateLimitStartMs - this.firstRateLimitAtMs,
-            });
-            await this.pauseWithCountdown(RATE_LIMIT_COOLDOWN_MS);
-            trackEvent('scrobble_rate_limit_cooldown_complete', {
-              scrobbled_tracks: this.scrobbledTracks,
-              total_tracks: tracks.length,
+            }));
+
+            if (this.rateLimitPauseCount > MAX_RATE_LIMIT_RETRIES) {
+              // Retrying further is not useful: recovery from a sustained rate
+              // limit takes hours, not minutes. Save and hand control back.
+              this.pauseReason = `Last.fm is still rate limiting your account after ${MAX_RATE_LIMIT_RETRIES} retries over ${formatDuration(Date.now() - this.firstRateLimitAtMs)}. This usually clears after a few hours — come back later and resume.`;
+              trackEvent('scrobble_paused', this.progressProps({
+                reason: 'rate_limit_exhausted',
+              }));
+              trackEvent('scrobble_rate_limit_gave_up', this.progressProps({
+                track_index: i,
+                burst_count: tracker.burstCount,
+                burst_limit: tracker.burstLimit,
+                daily_count: tracker.dailyCount,
+                rate_limit_pause_count: this.rateLimitPauseCount,
+                elapsed_since_first_rate_limit_ms: Date.now() - this.firstRateLimitAtMs,
+              }));
+              this.stopped = true;
+              this.paused = true;
+              this.autoSave();
+              return;
+            }
+
+            const backoffMs = RATE_LIMIT_BACKOFF_MS[this.rateLimitPauseCount - 1];
+            this.pauseReason = `Rate limited by Last.fm. Waiting ${formatDuration(backoffMs)} before retrying (attempt ${this.rateLimitPauseCount} of ${MAX_RATE_LIMIT_RETRIES}).`;
+            trackEvent('scrobble_paused', this.progressProps({ reason: 'rate_limit' }));
+            await this.pauseWithCountdown(backoffMs);
+            trackEvent('scrobble_rate_limit_cooldown_complete', this.progressProps({
               track_index: i,
-              burst_count: this.burstCount,
-              daily_count: this.dailyCount,
+              burst_count: tracker.burstCount,
+              burst_limit: tracker.burstLimit,
+              daily_count: tracker.dailyCount,
               rate_limit_pause_count: this.rateLimitPauseCount,
-              configured_cooldown_ms: RATE_LIMIT_COOLDOWN_MS,
+              configured_cooldown_ms: backoffMs,
               actual_pause_ms: Date.now() - rateLimitStartMs,
-            });
+            }));
             retrySameTrack = true;
           } else if (LastFm.isNetworkError(e)) {
             // Transient connectivity problem (offline, DNS, connection reset,
             // etc.). Don't count this against the track: pause briefly and retry
             // the same track once the network hopefully recovers.
             this.pauseReason = `Couldn't reach Last.fm (network error). Retrying in ${NETWORK_ERROR_COOLDOWN_SECONDS} seconds. Check your internet connection.`;
-            trackEvent('scrobble_paused', { reason: 'network_error', scrobbled_tracks: this.scrobbledTracks, total_tracks: tracks.length });
-            trackEvent('scrobble_network_error', {
-              scrobbled_tracks: this.scrobbledTracks,
-              total_tracks: tracks.length,
-              track_index: i,
-            });
+            trackEvent('scrobble_paused', this.progressProps({ reason: 'network_error' }));
+            trackEvent('scrobble_network_error', this.progressProps({ track_index: i }));
             await this.pauseWithCountdown(NETWORK_ERROR_COOLDOWN_MS);
             retrySameTrack = true;
           } else {
@@ -251,11 +529,9 @@ export default Vue.extend({
             consecutiveFailures++;
 
             if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-              trackError('scrobble.repeatedFailures', e, {
+              trackError('scrobble.repeatedFailures', e, this.progressProps({
                 consecutive_failures: consecutiveFailures,
-                scrobbled_tracks: this.scrobbledTracks,
-                failed_tracks: this.failedTracks.length,
-              });
+              }));
               this.errorMessage = `${MAX_CONSECUTIVE_FAILURES} tracks failed in a row. There may be a problem with Last.fm or your authentication.`;
               this.errorDetails = (e as Error).message || String(e);
               this.showError = true;
@@ -268,37 +544,38 @@ export default Vue.extend({
 
         if (!retrySameTrack) {
           this.scrobbledTracks += 1;
+          pendingReTagTimestampSec = undefined;
           if (recoveredFromRateLimit) {
-            trackEvent('scrobble_rate_limit_recovered', {
-              scrobbled_tracks: this.scrobbledTracks,
-              total_tracks: tracks.length,
+            trackEvent('scrobble_rate_limit_recovered', this.progressProps({
               burst_count: this.burstCount,
+              burst_limit: this.burstLimit,
               daily_count: this.dailyCount,
               rate_limit_pause_count: recoveredRateLimitPauseCount,
               elapsed_since_first_rate_limit_ms: elapsedSinceFirstRateLimitMs,
-            });
+            }));
           }
           i++;
         }
       }
 
       this.completed = true;
-      trackEvent('scrobble_completed', {
-        total_tracks: tracks.length,
-        scrobbled_tracks: this.scrobbledTracks,
-        failed_tracks: this.failedTracks.length,
-      });
+      trackEvent('scrobble_completed', this.progressProps());
       this.$emit('complete');
     },
 
     pauseWithCountdown(durationMs: number): Promise<void> {
       this.paused = true;
-      this.countdown = Math.ceil(durationMs / 1000);
+      const deadline = Date.now() + durationMs;
+      this.countdown = Math.ceil(durationMs / MS_PER_SECOND);
 
       return new Promise((resolve) => {
+        // Driven off a wall-clock deadline rather than by decrementing a
+        // counter: background tabs throttle setInterval, which would otherwise
+        // stretch a 30-minute backoff into something much longer.
         this.countdownTimer = window.setInterval(() => {
-          this.countdown--;
-          if (this.countdown <= 0) {
+          const remainingMs = deadline - Date.now();
+          this.countdown = Math.max(0, Math.ceil(remainingMs / MS_PER_SECOND));
+          if (remainingMs <= 0) {
             if (this.countdownTimer) {
               clearInterval(this.countdownTimer);
               this.countdownTimer = null;
@@ -313,16 +590,34 @@ export default Vue.extend({
 
     manualPause() {
       this.pauseReason = 'Manually paused.';
-      trackEvent('scrobble_paused', { reason: 'manual', scrobbled_tracks: this.scrobbledTracks, total_tracks: this.tracksToScrobble.length });
+      trackEvent('scrobble_paused', this.progressProps({ reason: 'manual' }));
       this.paused = true;
     },
 
+    /**
+     * Persist progress without downloading a file or navigating away, so the
+     * user can close the tab and resume later. Used when we stop retrying.
+     */
+    autoSave() {
+      this.$emit('auto-save', this.progressSnapshot());
+      this.autoSaved = true;
+    },
+
     saveAndExit() {
-      this.$emit('save-and-exit', {
+      this.$emit('save-and-exit', this.progressSnapshot());
+    },
+
+    progressSnapshot() {
+      const tracker = this.rateLimitTracker();
+      return {
         scrobbledTracks: this.scrobbledTracks,
-        burstCount: this.burstCount,
-        dailyCount: this.dailyCount,
-      });
+        originalTotalTracks: this.originalTotalTracks,
+        originalSucceededCount: this.totalSucceeded,
+        sendTimestamps: tracker.getSendTimestamps(),
+        lastReTagTimestampSec: this.reTagCursorSec,
+        burstCount: tracker.burstCount,
+        dailyCount: tracker.dailyCount,
+      };
     },
   },
 });

--- a/src/components/Scrobblify.vue
+++ b/src/components/Scrobblify.vue
@@ -37,7 +37,7 @@
       </v-stepper-header>
       <v-stepper-items>
         <v-stepper-content step="1">
-          <authenticate-step v-on:complete="currentStep = 2"></authenticate-step>
+          <authenticate-step v-on:complete="onAuthenticated"></authenticate-step>
         </v-stepper-content>
         <v-stepper-content step="2">
           <upload-step v-on:complete="currentStep = 3"></upload-step>
@@ -49,6 +49,7 @@
           <scrobble-step
             v-on:complete="onScrobbleComplete"
             v-on:save-and-exit="onSaveAndExit"
+            v-on:auto-save="onAutoSave"
           ></scrobble-step>
         </v-stepper-content>
         <v-stepper-content step="5">
@@ -75,8 +76,19 @@ import LastFm from '@/api/LastFm';
 import ScrobbleStepVue from '@/components/ScrobbleStep.vue';
 import CompleteStepVue from '@/components/CompleteStep.vue';
 import StateManager, { ScrobbleState } from '@/services/StateManager';
+import RateLimitTracker from '@/services/RateLimitTracker';
 import ErrorDialog from '@/components/ErrorDialog.vue';
 import { trackEvent, trackError, resetUser } from '@/services/Analytics';
+
+interface ProgressSnapshot {
+  scrobbledTracks: number;
+  originalTotalTracks: number;
+  originalSucceededCount: number;
+  sendTimestamps: number[];
+  lastReTagTimestampSec: number;
+  burstCount: number;
+  dailyCount: number;
+}
 
 export default Vue.extend({
   components: {
@@ -115,6 +127,37 @@ export default Vue.extend({
     stepName(step: number): string {
       return ['', 'authenticate', 'upload', 'select', 'scrobble', 'complete'][step] || String(step);
     },
+    /**
+     * AuthenticateStep confirms an existing session and then emits `complete`
+     * on a 2 second delay (so the "Checking for authentication..." spinner is
+     * readable). The user can act inside that window — most importantly they can
+     * hit "Resume", which jumps straight to the scrobble step. Advancing
+     * unconditionally would then yank them back to the upload step a moment
+     * later, losing the resumed session. Only ever move *forward* off step 1.
+     */
+    onAuthenticated() {
+      if (this.currentStep === 1) {
+        this.currentStep = 2;
+      }
+    },
+    /**
+     * `state.totalTracks` is only the tracks left to do, so on its own it makes
+     * a resumed import look smaller each time. Always report the original size
+     * and the cumulative progress alongside it.
+     */
+    resumeProps(state: ScrobbleState, source: string) {
+      const originalTotal = state.originalTotalTracks || state.totalTracks;
+      const succeeded = state.originalSucceededCount ?? state.completedIndices.length;
+      return {
+        source,
+        total_tracks: state.totalTracks,
+        original_total_tracks: originalTotal,
+        total_succeeded: succeeded,
+        completion_pct: originalTotal
+          ? Math.round((1000 * succeeded) / originalTotal) / 10
+          : 0,
+      };
+    },
     clearToken() {
       const api = this.$store.state.lfmApi as LastFm;
       this.currentStep = 1;
@@ -126,7 +169,7 @@ export default Vue.extend({
       try {
         const state = await this.stateManager.loadState();
         if (!state) { return; }
-        trackEvent('session_resumed', { source: 'saved', total_tracks: state.totalTracks });
+        trackEvent('session_resumed', this.resumeProps(state, 'saved'));
         this.restoreFromState(state);
       } catch (e) {
         trackError('scrobblify.resumeFromSaved', e);
@@ -143,7 +186,7 @@ export default Vue.extend({
       if (!input.files || input.files.length === 0) { return; }
       try {
         const state = await this.stateManager.importFromFile(input.files[0]);
-        trackEvent('session_resumed', { source: 'file', total_tracks: state.totalTracks });
+        trackEvent('session_resumed', this.resumeProps(state, 'file'));
         this.restoreFromState(state);
       } catch (e) {
         trackError('scrobblify.onImportFile', e);
@@ -160,6 +203,9 @@ export default Vue.extend({
         return;
       }
 
+      this.restoreRateLimitWindow(state, api.getUserName() || state.userName || null);
+      this.$store.commit('setReTagCursorSec', state.lastReTagTimestampSec || 0);
+
       // Restore remaining (not yet completed) tracks to store
       const allScrobbles = StateManager.deserializeScrobbles(state.tracks);
       const completedSet = new Set(state.completedIndices);
@@ -167,9 +213,37 @@ export default Vue.extend({
       const remaining = allScrobbles.filter((_, i) => !completedSet.has(i) && !failedSet.has(i));
 
       this.$store.commit('setSelectedScrobbles', remaining);
+      // The scrobble step only ever sees the remaining tracks, so it needs to be
+      // told separately that this is a resume — otherwise `scrobble_resumed`
+      // can never fire and the resume funnel is invisible. `originalTotalTracks`
+      // likewise has to be carried forward, since `remaining.length` shrinks on
+      // every resume and would otherwise make completion look better each time.
+      this.$store.commit('setResumedScrobbleCount', state.originalSucceededCount ?? completedSet.size);
+      this.$store.commit('setOriginalTotalTracks', state.originalTotalTracks || state.totalTracks);
       this.hasResumableState = false;
       // Skip to scrobble step (step 4)
       this.currentStep = 4;
+    },
+
+    /**
+     * Rate-limit budget is a property of the Last.fm *account*, not of a page
+     * load, so a restored session must restore it too. Files written before
+     * this existed only carry counts, which are converted to a (pessimistic)
+     * rolling window.
+     */
+    restoreRateLimitWindow(state: ScrobbleState, userName: string | null) {
+      try {
+        const tracker = new RateLimitTracker(userName);
+        if (Array.isArray(state.sendTimestamps) && state.sendTimestamps.length > 0) {
+          tracker.setSendTimestamps(state.sendTimestamps);
+        } else if (state.burstCount || state.dailyCount) {
+          const savedAtMs = state.savedAt ? new Date(state.savedAt).getTime() : Date.now();
+          tracker.seedFromLegacyCounts(state.burstCount, state.dailyCount, savedAtMs);
+        }
+      } catch (e) {
+        // A missing/corrupt rate-limit record must never block a restore; the
+        // tracker simply starts from an empty window.
+      }
     },
     async clearSavedState() {
       try {
@@ -185,10 +259,11 @@ export default Vue.extend({
       } catch (e) {
         // Not critical — continue anyway
       }
+      this.$store.commit('setResumedScrobbleCount', 0);
       this.hasRemainingTracks = false;
       this.currentStep = 5;
     },
-    async onSaveAndExit(info: { scrobbledTracks: number, burstCount: number, dailyCount: number }) {
+    buildState(info: ProgressSnapshot): ScrobbleState {
       const tracks = this.$store.state.selectedScrobbles as Scrobble[];
       const completedIndices: number[] = [];
       const failedIndices: number[] = [];
@@ -196,25 +271,56 @@ export default Vue.extend({
         completedIndices.push(i);
       }
 
-      const state: ScrobbleState = {
+      return {
         userName: (this.$store.state.lfmApi as LastFm).getUserName() || '',
         totalTracks: tracks.length,
         completedIndices,
         failedIndices,
         tracks: StateManager.serializeScrobbles(tracks),
+        originalTotalTracks: info.originalTotalTracks || tracks.length,
+        originalSucceededCount: info.originalSucceededCount,
+        sendTimestamps: info.sendTimestamps || [],
+        lastReTagTimestampSec: info.lastReTagTimestampSec || 0,
         burstCount: info.burstCount,
         dailyCount: info.dailyCount,
         dailyCountDate: new Date().toISOString().split('T')[0],
         savedAt: new Date().toISOString(),
       };
+    },
+    saveProps(info: ProgressSnapshot, automatic: boolean) {
+      const originalTotal = info.originalTotalTracks
+        || (this.$store.state.selectedScrobbles as Scrobble[]).length;
+      return {
+        automatic,
+        scrobbled_tracks: info.scrobbledTracks,
+        total_tracks: (this.$store.state.selectedScrobbles as Scrobble[]).length,
+        original_total_tracks: originalTotal,
+        total_succeeded: info.originalSucceededCount,
+        completion_pct: originalTotal
+          ? Math.round((1000 * info.originalSucceededCount) / originalTotal) / 10
+          : 0,
+      };
+    },
+    /**
+     * Silent save used when the scrobble step gives up (rate limited or daily
+     * limit reached). No file download and no navigation: the user stays on the
+     * explanation and can simply close the tab and come back.
+     */
+    async onAutoSave(info: ProgressSnapshot) {
+      try {
+        await this.stateManager.saveState(this.buildState(info));
+        trackEvent('session_saved', this.saveProps(info, true));
+      } catch (e) {
+        trackError('scrobblify.onAutoSave', e);
+      }
+    },
+    async onSaveAndExit(info: ProgressSnapshot) {
+      const state = this.buildState(info);
 
       try {
         await this.stateManager.saveState(state);
         this.stateManager.exportToFile(state);
-        trackEvent('session_saved', {
-          scrobbled_tracks: info.scrobbledTracks,
-          total_tracks: tracks.length,
-        });
+        trackEvent('session_saved', this.saveProps(info, false));
       } catch (e) {
         trackError('scrobblify.onSaveAndExit', e);
         this.errorMessage = 'Failed to save your scrobbling progress. You can try the "Save Progress" button again.';

--- a/src/components/SelectStep.vue
+++ b/src/components/SelectStep.vue
@@ -274,6 +274,7 @@ export default Vue.extend({
           artist: scrob.artistName,
           album: scrob.albumName,
           time: scrob.listenDate.getTime(),
+          reTagged: scrob.reTagged,
           originalTime: scrob.originalListenDate.getTime(),
           trackLower: scrob.trackName.toLowerCase(),
           artistLower: scrob.artistName.toLowerCase(),
@@ -505,8 +506,13 @@ export default Vue.extend({
         track.artist,
         new Date(track.time),
         track.album,
+        !!track.reTagged,
       ));
       this.$store.commit('setSelectedScrobbles', scrobbles);
+      // A fresh selection resets the resume lineage: this is the new "original"
+      // import that all later resume progress is measured against.
+      this.$store.commit('setOriginalTotalTracks', scrobbles.length);
+      this.$store.commit('setResumedScrobbleCount', 0);
       trackEvent('tracks_selected', {
         selected_count: selected.length,
         total_count: this.totalTrackCount,

--- a/src/components/UploadStep.vue
+++ b/src/components/UploadStep.vue
@@ -237,7 +237,7 @@ export default Vue.extend({
         newData = this.scrobblify.reTagOldListens(parsedData, reTagDate);
         this.logs.push(`No tracks removed - old listens have been moved to today (${reTagDate.toDateString()})`);
       } else {
-        newData = this.scrobblify.removeOldListens(parsedData, this.scrobbleOldPlays);
+        newData = this.scrobblify.removeOldListens(parsedData);
         this.logs.push(`Found ${newData.length} tracks that were listened to in the last two weeks`);
       }
 

--- a/src/models/Scrobble.ts
+++ b/src/models/Scrobble.ts
@@ -4,6 +4,17 @@ export default class Scrobble {
     public artist: string,
     public timestamp: Date,
     public album: string = '',
+    /**
+     * True when `timestamp` is a synthetic stand-in rather than a real listen
+     * date, because the user asked to scrobble plays older than Last.fm's
+     * 14-day retroactive limit.
+     *
+     * These must be re-stamped relative to the clock at send time. Baking an
+     * absolute date in at parse time breaks resumes: a queue saved today and
+     * resumed three weeks later would carry timestamps Last.fm now rejects as
+     * too old (ignore code 3).
+     */
+    public reTagged: boolean = false,
   ) {
   }
 

--- a/src/models/SpotifyListen.ts
+++ b/src/models/SpotifyListen.ts
@@ -4,6 +4,9 @@ export default class SpotifyListen {
 
   public originalListenDate: Date;
 
+  /** See Scrobble.reTagged — set by Scrobblify.reTagOldListens. */
+  public reTagged = false;
+
   constructor(
     public artistName: string,
     public trackName: string,

--- a/src/scrobblify.ts
+++ b/src/scrobblify.ts
@@ -60,12 +60,27 @@ export default class Scrobblify {
 
     const SAME_IF_COEFFICIENT_ABOVE = 0.9;
 
+    // Re-tagged plays carry provisional timestamps that are discarded and
+    // re-allocated at send time, so matching them against real history compares
+    // fiction against fact. Now that those timestamps are spread out rather
+    // than collapsed onto a single instant, the comparison window spans hours
+    // of genuine listening, and any import row whose fake second happens to
+    // land near a real recent play of the same track would be silently dropped.
+    //
+    // Their true dates survive on `originalListenDate`, but checking against
+    // those would mean fetching the user's entire Last.fm history back to the
+    // start of the export — potentially years. So they are simply exempt.
+    const checkable = listens.filter((listen) => !listen.reTagged);
+    if (checkable.length === 0) {
+      return { unique: listens, duplicateCount: 0 };
+    }
+
     // Determine the date range of the Spotify data (with buffer).
     // Iterate rather than spreading into Math.min/Math.max, which overflows the
     // call stack for large histories (tens of thousands of listens).
-    let minTimestamp = listens[0].listenDate.getTime();
+    let minTimestamp = checkable[0].listenDate.getTime();
     let maxTimestamp = minTimestamp;
-    for (const listen of listens) {
+    for (const listen of checkable) {
       const time = listen.listenDate.getTime();
       if (time < minTimestamp) {
         minTimestamp = time;
@@ -109,6 +124,9 @@ export default class Scrobblify {
     // Filter locally
     let duplicateCount = 0;
     const unique = listens.filter((listen) => {
+      if (listen.reTagged) {
+        return true;
+      }
       const artistKey = listen.artistName.toLowerCase();
       const candidates = scrobblesByArtist.get(artistKey);
       if (!candidates) {
@@ -250,7 +268,7 @@ export default class Scrobblify {
     In addition, the last.fm scrobbling api only allows 14 days prior to be scrobbled:
     https://getsatisfaction.com/lastfm/topics/scrobbles-more-than-14-days
   */
-  public removeOldListens(listens: SpotifyListen[], reTagOldListens = false): SpotifyListen[] {
+  public removeOldListens(listens: SpotifyListen[]): SpotifyListen[] {
     return listens.filter((listen) => {
       const currentTrackStartedAt = listen.listenDate.getTime();
       return (currentTrackStartedAt > this.retroactiveScrobbleLimitDate);
@@ -258,14 +276,27 @@ export default class Scrobblify {
   }
 
   /*
-    The 14 day limit can be circumvented by changing the listen date to a day within the last two weeks
+    The 14 day limit can be circumvented by changing the listen date to a day within the last two weeks.
+
+    Every listen must land on its own second. Last.fm keys a scrobble on
+    (user, artist, track, timestamp), so giving every play the same timestamp —
+    as this used to — silently collapses repeat listens of a track down to a
+    single scrobble and throws the rest away.
+
+    These dates are provisional. `reTagged` marks them so the scrobble loop can
+    re-stamp each play against the clock at send time, which is what actually
+    keeps a long-running or resumed import inside the 14-day window.
   */
   public reTagOldListens(listens: SpotifyListen[], newDate: Date): SpotifyListen[] {
-    return listens.map((listen) => {
+    const endMs = newDate.getTime();
+    const startMs = endMs - Math.max(0, listens.length - 1) * this.SECONDS_TO_MS;
+    return listens.map((listen, i) => {
       // Mutated in place on purpose: SpotifyListen is a class, so cloning it
       // here would drop its prototype (and `originalListenDate`).
-      // eslint-disable-next-line no-param-reassign
-      listen.listenDate = newDate;
+      /* eslint-disable no-param-reassign */
+      listen.listenDate = new Date(startMs + i * this.SECONDS_TO_MS);
+      listen.reTagged = true;
+      /* eslint-enable no-param-reassign */
       return listen;
     });
   }

--- a/src/services/RateLimitTracker.ts
+++ b/src/services/RateLimitTracker.ts
@@ -1,0 +1,291 @@
+import { trackEvent } from '@/services/Analytics';
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+
+/*
+  Last.fm enforces its scrobble limits as a *rolling window* on the account, not
+  as a fixed count that resets when our page reloads. The previous
+  implementation counted scrobbles in a plain in-memory integer that started at
+  zero on every mount, so a user who came back after being throttled immediately
+  spent a budget they did not have. Telemetry showed 50% of first-in-streak rate
+  limits happening at a burst count of zero.
+
+  This tracker instead keeps the timestamps of recent successful scrobbles,
+  persists them per Last.fm user, and answers the only question the scrobble
+  loop actually cares about: "is it safe to send right now, and if not, for how
+  long must I wait?".
+*/
+
+export const BURST_WINDOW_MS = 10 * MS_PER_MINUTE;
+export const DAILY_WINDOW_MS = 24 * MS_PER_HOUR;
+
+// Highest burst ever observed at the moment of a rate limit was 849, p90 was
+// 747. We start meaningfully below that rather than at the old 950, and let the
+// adaptive limit below discover each account's real ceiling from there.
+export const DEFAULT_BURST_LIMIT = 500;
+
+// Never throttle ourselves below this; at some point a smaller limit stops
+// being caution and starts being a broken app.
+export const MIN_BURST_LIMIT = 50;
+
+// Last.fm's daily ceiling. Unlike the burst limit this one is well established,
+// so it is not adapted — but it is now measured over a rolling 24 hours rather
+// than a calendar day, which is both what Last.fm enforces and what removes the
+// need for any day-rollover bookkeeping.
+export const DAILY_LIMIT = 2700;
+
+// When we do get rate limited, the number of sends we managed inside the burst
+// window is direct evidence of where the real ceiling sits. Back off to a
+// fraction of that so the next window stays clear of it.
+const ADAPTIVE_BACKOFF_FACTOR = 0.8;
+
+// Sustained success is evidence the limit is too conservative, so creep back up.
+const ADAPTIVE_RECOVERY_FACTOR = 0.25;
+const ADAPTIVE_RECOVERY_MIN_STEP = 25;
+const ADAPTIVE_RECOVERY_AFTER_SENDS = 150;
+
+const STORAGE_KEY_PREFIX = 'scrobblifyRateLimit';
+const ANONYMOUS_USER_KEY = '__anonymous__';
+
+interface PersistedRateLimitData {
+  sends: number[];
+  burstLimit: number;
+  sendsSinceRateLimit: number;
+}
+
+export default class RateLimitTracker {
+  private sends: number[] = [];
+
+  private burstLimitValue: number = DEFAULT_BURST_LIMIT;
+
+  private sendsSinceRateLimit = 0;
+
+  private readonly storageKey: string;
+
+  constructor(userName: string | null) {
+    this.storageKey = `${STORAGE_KEY_PREFIX}:${userName || ANONYMOUS_USER_KEY}`;
+    this.load();
+  }
+
+  public get burstLimit(): number {
+    return this.burstLimitValue;
+  }
+
+  public get dailyLimit(): number {
+    return DAILY_LIMIT;
+  }
+
+  public get burstCount(): number {
+    return this.countSince(Date.now() - BURST_WINDOW_MS);
+  }
+
+  public get dailyCount(): number {
+    return this.countSince(Date.now() - DAILY_WINDOW_MS);
+  }
+
+  /**
+   * How long the caller must wait before a send would fit inside the burst
+   * window. Zero means "safe to send now".
+   */
+  public msUntilBurstSafe(): number {
+    return this.msUntilWindowHasRoom(BURST_WINDOW_MS, this.burstLimitValue);
+  }
+
+  /**
+   * How long the caller must wait before a send would fit inside the 24 hour
+   * window. Zero means "safe to send now".
+   */
+  public msUntilDailySafe(): number {
+    return this.msUntilWindowHasRoom(DAILY_WINDOW_MS, DAILY_LIMIT);
+  }
+
+  public recordSend(timestamp: number = Date.now()): void {
+    this.sends.push(timestamp);
+    this.sendsSinceRateLimit += 1;
+
+    if (this.sendsSinceRateLimit >= ADAPTIVE_RECOVERY_AFTER_SENDS
+      && this.burstLimitValue < DEFAULT_BURST_LIMIT) {
+      const step = Math.max(
+        ADAPTIVE_RECOVERY_MIN_STEP,
+        Math.floor(this.burstLimitValue * ADAPTIVE_RECOVERY_FACTOR),
+      );
+      this.burstLimitValue = Math.min(DEFAULT_BURST_LIMIT, this.burstLimitValue + step);
+      this.sendsSinceRateLimit = 0;
+      trackEvent('scrobble_burst_limit_raised', { burst_limit: this.burstLimitValue });
+    }
+
+    this.prune();
+    this.save();
+  }
+
+  /**
+   * Called when Last.fm actually rate limited us. The number of sends inside
+   * the current burst window is evidence of where the real ceiling is, so pull
+   * the limit down below it.
+   *
+   * If the window is (nearly) empty the limit cannot be what caused this — the
+   * account was throttled by something outside our view, such as another device
+   * or a session older than the window. Lowering our limit on that evidence
+   * would cripple pacing for no reason, so we leave it alone.
+   */
+  public recordRateLimit(): void {
+    const observed = this.burstCount;
+    const previousLimit = this.burstLimitValue;
+    this.sendsSinceRateLimit = 0;
+
+    if (observed > MIN_BURST_LIMIT) {
+      this.burstLimitValue = Math.max(
+        MIN_BURST_LIMIT,
+        Math.min(this.burstLimitValue, Math.floor(observed * ADAPTIVE_BACKOFF_FACTOR)),
+      );
+    }
+    this.save();
+
+    if (this.burstLimitValue !== previousLimit) {
+      trackEvent('scrobble_burst_limit_lowered', {
+        burst_limit: this.burstLimitValue,
+        previous_burst_limit: previousLimit,
+        observed_burst_count: observed,
+      });
+    }
+  }
+
+  /**
+   * Seed the window from a legacy saved session that only recorded counts, not
+   * timestamps. The individual send times are unknown, so they are treated as
+   * having happened in the run-up to `savedAtMs` — pessimistic by design, since
+   * assuming the budget is already spent is far cheaper than assuming it is free.
+   *
+   * Anything that has since aged out of its window is dropped by `prune()` and
+   * by the window queries, so an old save correctly contributes nothing.
+   */
+  public seedFromLegacyCounts(burstCount: number, dailyCount: number, savedAtMs: number): void {
+    if (this.sends.length > 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const savedAt = Number.isFinite(savedAtMs) ? Math.min(savedAtMs, now) : now;
+    const safeDaily = Math.max(0, Math.floor(dailyCount));
+    const safeBurst = Math.min(Math.max(0, Math.floor(burstCount)), safeDaily || 0);
+
+    const seeded: number[] = [];
+    // Sends older than the burst window, spread back over the preceding 24h.
+    const olderDaily = safeDaily - safeBurst;
+    for (let i = 0; i < olderDaily; i++) {
+      const age = BURST_WINDOW_MS
+        + ((DAILY_WINDOW_MS - BURST_WINDOW_MS) * (olderDaily - i)) / (olderDaily + 1);
+      seeded.push(savedAt - age);
+    }
+    // The burst sends are the most recent ones, immediately before the save.
+    for (let i = 0; i < safeBurst; i++) {
+      seeded.push(savedAt - (BURST_WINDOW_MS * (safeBurst - i)) / (safeBurst + 1));
+    }
+
+    this.sends = seeded;
+    this.prune();
+    this.save();
+  }
+
+  public getSendTimestamps(): number[] {
+    this.prune();
+    return [...this.sends];
+  }
+
+  public setSendTimestamps(timestamps: number[]): void {
+    this.sends = timestamps.filter((t) => typeof t === 'number' && Number.isFinite(t));
+    this.prune();
+    this.save();
+  }
+
+  public clear(): void {
+    this.sends = [];
+    this.burstLimitValue = DEFAULT_BURST_LIMIT;
+    this.sendsSinceRateLimit = 0;
+    try {
+      localStorage.removeItem(this.storageKey);
+    } catch (e) {
+      // Storage unavailable (private mode, quota, disabled) — not fatal.
+    }
+  }
+
+  private countSince(cutoff: number): number {
+    let count = 0;
+    for (let i = this.sends.length - 1; i >= 0; i--) {
+      if (this.sends[i] < cutoff) {
+        break;
+      }
+      count++;
+    }
+    return count;
+  }
+
+  private msUntilWindowHasRoom(windowMs: number, limit: number): number {
+    const now = Date.now();
+    const cutoff = now - windowMs;
+    const inWindow = this.countSince(cutoff);
+    if (inWindow < limit) {
+      return 0;
+    }
+    // The oldest send we need to expire is the one `limit - 1` back from the
+    // newest; once it leaves the window there is room for exactly one more.
+    const index = this.sends.length - limit;
+    const oldestRelevant = this.sends[Math.max(0, index)];
+    return Math.max(0, (oldestRelevant + windowMs) - now);
+  }
+
+  private prune(): void {
+    const cutoff = Date.now() - DAILY_WINDOW_MS;
+    // `sends` is append-only in ascending order, so everything before the first
+    // in-window entry can be dropped in one slice.
+    let firstValid = 0;
+    while (firstValid < this.sends.length && this.sends[firstValid] < cutoff) {
+      firstValid++;
+    }
+    if (firstValid > 0) {
+      this.sends = this.sends.slice(firstValid);
+    }
+  }
+
+  private load(): void {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw) as PersistedRateLimitData;
+      if (Array.isArray(parsed.sends)) {
+        this.sends = parsed.sends.filter((t) => typeof t === 'number' && Number.isFinite(t));
+      }
+      if (typeof parsed.burstLimit === 'number' && Number.isFinite(parsed.burstLimit)) {
+        this.burstLimitValue = Math.min(
+          DEFAULT_BURST_LIMIT,
+          Math.max(MIN_BURST_LIMIT, parsed.burstLimit),
+        );
+      }
+      if (typeof parsed.sendsSinceRateLimit === 'number') {
+        this.sendsSinceRateLimit = parsed.sendsSinceRateLimit;
+      }
+      this.prune();
+    } catch (e) {
+      // Corrupt or unavailable storage — fall back to a clean window.
+      this.sends = [];
+    }
+  }
+
+  private save(): void {
+    try {
+      const data: PersistedRateLimitData = {
+        sends: this.sends,
+        burstLimit: this.burstLimitValue,
+        sendsSinceRateLimit: this.sendsSinceRateLimit,
+      };
+      localStorage.setItem(this.storageKey, JSON.stringify(data));
+    } catch (e) {
+      // Storage unavailable or over quota. Losing persistence degrades us to
+      // the old in-memory behaviour rather than breaking scrobbling.
+    }
+  }
+}

--- a/src/services/StateManager.ts
+++ b/src/services/StateManager.ts
@@ -5,6 +5,12 @@ export interface SerializedScrobble {
   artist: string;
   album: string;
   timestamp: number;
+  /**
+   * Absent in files written before re-tagged plays were given per-play
+   * timestamps. deserializeScrobbles() infers it for those — see
+   * hasCollapsedTimestamps().
+   */
+  reTagged?: boolean;
 }
 
 export interface ScrobbleState {
@@ -13,6 +19,34 @@ export interface ScrobbleState {
   completedIndices: number[];
   failedIndices: number[];
   tracks: SerializedScrobble[];
+  /**
+   * Size of the user's *original* selection. `totalTracks` shrinks on every
+   * resume (only the remaining tracks are re-saved), so it cannot be used as a
+   * completion denominator. This one is carried forward untouched.
+   */
+  originalTotalTracks: number;
+  /**
+   * Cumulative count of tracks successfully scrobbled across every session of
+   * this import, not just the most recent one.
+   */
+  originalSucceededCount: number;
+  /**
+   * Timestamps (ms) of recent successful scrobbles — the rolling window used by
+   * RateLimitTracker. This is the authoritative rate-limit record.
+   */
+  sendTimestamps: number[];
+  /**
+   * High-water mark of the send-time timestamp allocator for re-tagged plays.
+   * Optional: absent from files written before it existed, in which case the
+   * allocator simply starts from the current clock.
+   */
+  lastReTagTimestampSec?: number;
+  /**
+   * Legacy count-based rate-limit fields. Kept so progress files written by
+   * older versions still import, and so files written by this version remain
+   * readable by them. RateLimitTracker.seedFromLegacyCounts() converts these
+   * into a rolling window when sendTimestamps is absent.
+   */
   burstCount: number;
   dailyCount: number;
   dailyCountDate: string;
@@ -30,11 +64,54 @@ export default class StateManager {
       artist: s.artist,
       album: s.album,
       timestamp: s.timestamp.getTime(),
+      reTagged: s.reTagged,
     }));
   }
 
+  /**
+   * Older versions stamped every re-tagged play with the same Date object, so a
+   * saved queue from one of those is recognisable by essentially *all* of its
+   * timestamps being identical — real listening history never looks like that.
+   *
+   * Without this, someone mid-import from an older build would resume into a
+   * queue that Last.fm collapses into a single scrobble, and (once the saved
+   * date ages past 14 days) rejects outright.
+   *
+   * The thresholds are deliberately strict. A saved file holds only the
+   * *remaining* queue, so a near-finished import can be down to a handful of
+   * tracks, and Spotify exports do contain occasional genuinely-identical
+   * second-precision timestamps. A loose test would re-stamp those real listen
+   * dates — corrupting good data to rescue bad. The bug being migrated produced
+   * identical timestamps for 100% of entries, so demanding 90% costs nothing.
+   */
+  static hasCollapsedTimestamps(data: SerializedScrobble[]): boolean {
+    const MIN_SAMPLE = 20;
+    const MIN_SHARE = 0.9;
+    if (data.length < MIN_SAMPLE) {
+      return false;
+    }
+    const counts = new Map<number, number>();
+    let mostCommon = 0;
+    for (const d of data) {
+      const next = (counts.get(d.timestamp) || 0) + 1;
+      counts.set(d.timestamp, next);
+      if (next > mostCommon) {
+        mostCommon = next;
+      }
+    }
+    return mostCommon >= data.length * MIN_SHARE;
+  }
+
   static deserializeScrobbles(data: SerializedScrobble[]): Scrobble[] {
-    return data.map((d) => new Scrobble(d.track, d.artist, new Date(d.timestamp), d.album));
+    const inferReTagged = data.some((d) => d.reTagged === undefined)
+      && StateManager.hasCollapsedTimestamps(data);
+    return data.map((d) => new Scrobble(
+      d.track,
+      d.artist,
+      new Date(d.timestamp),
+      d.album,
+      d.reTagged ?? inferReTagged,
+    ));
   }
 
   public async saveState(state: ScrobbleState): Promise<void> {
@@ -115,11 +192,20 @@ export default class StateManager {
 
     return {
       userName: '',
+      sendTimestamps: [],
+      lastReTagTimestampSec: 0,
       burstCount: 0,
       dailyCount: 0,
       dailyCountDate: new Date().toISOString().split('T')[0],
       savedAt: new Date().toISOString(),
       ...data,
+      // Files written before these existed have no lineage information, so the
+      // best available approximation is this file's own totals. Applied after
+      // the spread so a genuinely absent field is filled rather than kept as
+      // undefined.
+      originalTotalTracks: data.originalTotalTracks || data.totalTracks,
+      originalSucceededCount: data.originalSucceededCount
+        ?? (Array.isArray(data.completedIndices) ? data.completedIndices.length : 0),
     } as ScrobbleState;
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,18 @@ export default new Vuex.Store({
     selectedScrobbles: [],
     tracksScrobbled: 0,
     tracksFailed: 0,
+    // Number of tracks already scrobbled in a previously saved session that is
+    // being resumed. `selectedScrobbles` only ever holds the *remaining* tracks,
+    // so this is the only way the scrobble step can tell a resume from a fresh
+    // start (without it, `scrobble_resumed` could never fire).
+    resumedScrobbleCount: 0,
+    // Size of the user's original selection. Unlike `selectedScrobbles.length`
+    // this does NOT shrink on resume, so it is the only stable denominator for
+    // "how much of my import is done" — both in the UI and in analytics.
+    originalTotalTracks: 0,
+    // High-water mark of the re-tagged-play timestamp allocator, carried across
+    // a resume so a later run cannot reuse seconds an earlier one already sent.
+    reTagCursorSec: 0,
   },
   mutations: {
     setValidScrobbles(state: any, tracks: SpotifyListen[]) {
@@ -21,6 +33,15 @@ export default new Vuex.Store({
     },
     setSelectedScrobbles(state: any, tracks: Scrobble[]) {
       Vue.set(state, 'selectedScrobbles', tracks);
+    },
+    setResumedScrobbleCount(state: any, count: number) {
+      state.resumedScrobbleCount = count;
+    },
+    setOriginalTotalTracks(state: any, count: number) {
+      state.originalTotalTracks = count;
+    },
+    setReTagCursorSec(state: any, seconds: number) {
+      state.reTagCursorSec = seconds;
     },
     trackScrobbled(state: any) {
       state.tracksScrobbled += 1;

--- a/tests/scrobblify.spec.ts
+++ b/tests/scrobblify.spec.ts
@@ -534,6 +534,278 @@ test.describe('LastFm API client', () => {
   });
 });
 
+test.describe('Session Resume', () => {
+  // Writes a saved session straight into IndexedDB, which is exactly what
+  // `StateManager.saveState` produces. Lets the resume path be exercised
+  // without first having to drive a real pause.
+  async function seedSavedState(page: Page, state: Record<string, unknown>) {
+    await page.evaluate(async (savedState) => {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('scrobblify', 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains('scrobbleState')) {
+            db.createObjectStore('scrobbleState');
+          }
+        };
+        request.onsuccess = () => {
+          const db = request.result;
+          const tx = db.transaction('scrobbleState', 'readwrite');
+          tx.objectStore('scrobbleState').put(savedState, 'current');
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => { db.close(); reject(tx.error); };
+        };
+        request.onerror = () => reject(request.error);
+      });
+    }, state);
+  }
+
+  function buildState(overrides: Record<string, unknown> = {}) {
+    const tracks = [1, 2, 3, 4, 5].map((n) => ({
+      track: `Track ${n}`,
+      artist: `Artist ${n}`,
+      album: `Album ${n}`,
+      timestamp: Date.UTC(2024, 0, n),
+    }));
+    return {
+      userName: 'testuser',
+      totalTracks: 5,
+      completedIndices: [0, 1, 2],
+      failedIndices: [],
+      tracks,
+      originalTotalTracks: 5,
+      originalSucceededCount: 3,
+      sendTimestamps: [],
+      burstCount: 0,
+      dailyCount: 0,
+      dailyCountDate: new Date().toISOString().split('T')[0],
+      savedAt: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  test('resuming scrobbles only the remaining tracks', async ({ page }) => {
+    const scrobbled: string[] = [];
+    await interceptLastFm(page);
+    await page.route('https://ws.audioscrobbler.com/**', async (route: Route) => {
+      const params = new URLSearchParams(
+        route.request().method() === 'POST'
+          ? route.request().postData() || ''
+          : new URL(route.request().url()).search,
+      );
+      if (params.get('method') === 'track.scrobble') {
+        scrobbled.push(params.get('track[0]') || '');
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ scrobbles: { '@attr': { accepted: 1, ignored: 0 } } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await seedSavedState(page, buildState());
+    await page.reload();
+
+    await expect(page.locator('text=Resume previous session?')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Resume', exact: true }).click();
+
+    // Only the 2 not-yet-completed tracks should be queued...
+    await expect(page.locator('text=2 tracks ready to scrobble')).toBeVisible({ timeout: 5000 });
+    // ...but progress must still be reported against the original import size,
+    // not against the shrunken remainder.
+    await expect(page.locator('.overall-progress')).toContainText('3 of 5');
+
+    // Outlast AuthenticateStep's delayed `complete` emit before interacting, so
+    // the click can't race the stepper transition it used to trigger.
+    await page.waitForTimeout(2500);
+    await page.getByRole('button', { name: 'Scrobble', exact: true }).click();
+    await expect(page.locator('text=Finished scrobbling')).toBeVisible({ timeout: 30000 });
+
+    expect(scrobbled).toEqual(['Track 4', 'Track 5']);
+  });
+
+  test('resuming immediately is not undone by the delayed auth redirect', async ({ page }) => {
+    // Regression: AuthenticateStep emits `complete` on a 2s setTimeout. Resuming
+    // inside that window used to jump to the scrobble step and then get dragged
+    // back to the upload step, silently losing the resumed session.
+    await interceptLastFm(page);
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await seedSavedState(page, buildState());
+    await page.reload();
+
+    await expect(page.locator('text=Resume previous session?')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Resume', exact: true }).click();
+    await expect(page.locator('text=2 tracks ready to scrobble')).toBeVisible({ timeout: 5000 });
+
+    // Outlast the delayed auth emit, then confirm we're still on the scrobble step.
+    await page.waitForTimeout(4000);
+    await expect(page.locator('text=2 tracks ready to scrobble')).toBeVisible();
+    await expect(page.locator('.upload-step')).toBeHidden();
+  });
+
+  test('a resumed session reports overall progress, not just the remaining chunk', async ({ page }) => {
+    await interceptLastFm(page);
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    // A third session: 5 of 10 already done, only 2 tracks left in this chunk.
+    await seedSavedState(page, buildState({
+      totalTracks: 5,
+      completedIndices: [0, 1, 2],
+      originalTotalTracks: 10,
+      originalSucceededCount: 5,
+    }));
+    await page.reload();
+
+    await expect(page.locator('text=Resume previous session?')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Resume', exact: true }).click();
+
+    await expect(page.locator('.overall-progress')).toContainText('5 of 10');
+  });
+
+  test('legacy progress files without lineage fields still resume', async ({ page }) => {
+    await interceptLastFm(page);
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    const legacy = buildState();
+    delete (legacy as Record<string, unknown>).originalTotalTracks;
+    delete (legacy as Record<string, unknown>).originalSucceededCount;
+    delete (legacy as Record<string, unknown>).sendTimestamps;
+    await seedSavedState(page, legacy);
+    await page.reload();
+
+    await expect(page.locator('text=Resume previous session?')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Resume', exact: true }).click();
+
+    await expect(page.locator('text=2 tracks ready to scrobble')).toBeVisible({ timeout: 5000 });
+    // Falls back to this file's own totals rather than reporting nothing.
+    await expect(page.locator('.overall-progress')).toContainText('3 of 5');
+  });
+});
+
+test.describe('Rate limit handling', () => {
+  // Always rate-limited. Also short-circuits LastFm's own internal retry
+  // budget so the component-level backoff is what's under test.
+  async function alwaysRateLimited(page: Page) {
+    await page.route('https://ws.audioscrobbler.com/**', async (route: Route) => {
+      const params = new URLSearchParams(
+        route.request().method() === 'POST'
+          ? route.request().postData() || ''
+          : new URL(route.request().url()).search,
+      );
+      const apiMethod = params.get('method');
+      if (apiMethod === 'track.scrobble') {
+        await route.fulfill({
+          status: 429,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 29, message: 'Rate limit exceeded' }),
+        });
+        return;
+      }
+      if (apiMethod === 'auth.getSession') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ session: { name: 'testuser', key: 'fake-session-key' } }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ recenttracks: { track: [] } }),
+      });
+    });
+  }
+
+  async function seedSelection(page: Page) {
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('scrobblify', 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains('scrobbleState')) {
+            db.createObjectStore('scrobbleState');
+          }
+        };
+        request.onsuccess = () => {
+          const db = request.result;
+          const tx = db.transaction('scrobbleState', 'readwrite');
+          tx.objectStore('scrobbleState').put({
+            userName: 'testuser',
+            totalTracks: 2,
+            completedIndices: [],
+            failedIndices: [],
+            tracks: [1, 2].map((n) => ({
+              track: `Track ${n}`, artist: `Artist ${n}`, album: '', timestamp: Date.UTC(2024, 0, n),
+            })),
+            originalTotalTracks: 2,
+            originalSucceededCount: 0,
+            sendTimestamps: [],
+            burstCount: 0,
+            dailyCount: 0,
+            dailyCountDate: new Date().toISOString().split('T')[0],
+            savedAt: new Date().toISOString(),
+          }, 'current');
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => { db.close(); reject(tx.error); };
+        };
+        request.onerror = () => reject(request.error);
+      });
+    });
+  }
+
+  test('gives up and saves instead of retrying a rate limit forever', async ({ page }) => {
+    // Regression: the old handler paused a flat 60s and retried the same track
+    // indefinitely. Two production users sat through 200+ consecutive retries.
+    //
+    // The backoff ladder spans ~50 minutes, so time is faked. With the clock
+    // frozen nothing advances on its own — including the API client's own retry
+    // backoff — so the clock has to be driven forward while polling.
+    await page.clock.install();
+    await alwaysRateLimited(page);
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await seedSelection(page);
+    await page.reload();
+
+    await expect(page.locator('text=Resume previous session?')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Resume', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Scrobble', exact: true })).toBeVisible();
+    await page.clock.runFor(3000);
+    await page.getByRole('button', { name: 'Scrobble', exact: true }).click();
+
+    // Advance simulated time until the loop reaches a terminal state, recording
+    // whether the escalating backoff was surfaced along the way.
+    let sawFirstBackoff = false;
+    let gaveUp = false;
+    for (let i = 0; i < 250 && !gaveUp; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await page.clock.runFor(30 * 1000);
+      // eslint-disable-next-line no-await-in-loop
+      await page.waitForTimeout(50);
+      if (!sawFirstBackoff) {
+        // eslint-disable-next-line no-await-in-loop
+        sawFirstBackoff = await page.locator('text=attempt 1 of 3').isVisible();
+      }
+      // eslint-disable-next-line no-await-in-loop
+      gaveUp = await page.locator('text=still rate limiting your account').isVisible();
+    }
+
+    // The user is told how long we'll wait, instead of a bare 1-minute countdown.
+    expect(sawFirstBackoff).toBe(true);
+    // The loop must terminate with an actionable message, not keep spinning.
+    expect(gaveUp).toBe(true);
+    await expect(page.getByRole('button', { name: 'Try Again Now' })).toBeVisible();
+    // ...and progress must have been saved automatically so the user can leave.
+    await expect(page.locator('text=saved automatically')).toBeVisible();
+  });
+});
+
 test.describe('Complete Step', () => {
   test('shows completion message after full scrobble', async ({ page }) => {
     await interceptLastFm(page);
@@ -674,5 +946,135 @@ test.describe('No JS Errors', () => {
     await page.goto('/#/scrobble');
     await page.waitForTimeout(2000);
     expect(errors).toEqual([]);
+  });
+});
+
+test.describe('Re-tagged old plays', () => {
+  // Drives an import with "Scrobble tracks older than 2 weeks" enabled, which is
+  // the path ~78% of real imports take, and hands back every timestamp Last.fm
+  // was asked to store.
+  async function runReTaggedImport(
+    page: Page,
+    scrobbleResponse: object | ((attempt: number) => object | 'abort'),
+  ) {
+    const timestamps: number[] = [];
+    let scrobbleAttempts = 0;
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const postData = route.request().postData() || '';
+      const allParams = new URLSearchParams(
+        route.request().method() === 'POST' ? postData : new URL(route.request().url()).search,
+      );
+      const apiMethod = allParams.get('method');
+
+      if (apiMethod === 'track.scrobble') {
+        const raw = allParams.get('timestamp%5B0%5D') || allParams.get('timestamp[0]') || '0';
+        timestamps.push(Number(raw));
+        scrobbleAttempts++;
+        const outcome = typeof scrobbleResponse === 'function'
+          ? scrobbleResponse(scrobbleAttempts)
+          : scrobbleResponse;
+        if (outcome === 'abort') {
+          await route.abort('connectionfailed');
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(outcome),
+        });
+      } else if (apiMethod === 'track.getInfo') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ track: { duration: '240000' } }),
+        });
+      } else if (apiMethod === 'user.getrecenttracks') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ recenttracks: { track: [] } }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ session: { name: 'testuser', key: 'fake-session-key' } }),
+        });
+      }
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    await page.locator('input[type="file"][accept=".zip"]').setInputFiles(FIXTURE_ZIP);
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    await expect(page.locator('button:has-text("Choose which tracks to scrobble")')).toBeVisible({ timeout: 30000 });
+    await page.locator('button:has-text("Choose which tracks to scrobble")').click();
+    await expect(page.locator('button:has-text("matching")')).toBeVisible({ timeout: 5000 });
+    await page.locator('button:has-text("matching")').click();
+    await page.locator('button:has-text("selected tracks")').click();
+
+    await expect(page.getByRole('button', { name: 'Scrobble', exact: true })).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: 'Scrobble', exact: true }).click();
+    await expect(page.locator('text=Finished scrobbling')).toBeVisible({ timeout: 30000 });
+
+    return timestamps;
+  }
+
+  test('gives every re-tagged play its own timestamp so repeats are not collapsed', async ({ page }) => {
+    const timestamps = await runReTaggedImport(page, { scrobbles: { '@attr': { accepted: 1, ignored: 0 } } });
+
+    expect(timestamps.length).toBeGreaterThan(1);
+    // The bug: every play shared one Date, so Last.fm — which keys a scrobble on
+    // (user, artist, track, timestamp) — kept one and silently dropped the rest.
+    expect(new Set(timestamps).size).toBe(timestamps.length);
+
+    const sorted = [...timestamps].sort((a, b) => a - b);
+    expect(timestamps).toEqual(sorted);
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fourteenDaysSec = 14 * 24 * 60 * 60;
+    for (const ts of timestamps) {
+      expect(ts).toBeLessThanOrEqual(nowSec);
+      expect(ts).toBeGreaterThan(nowSec - fourteenDaysSec);
+    }
+  });
+
+  test('a scrobble Last.fm ignored is reported as failed, not scrobbled', async ({ page }) => {
+    const timestamps = await runReTaggedImport(page, {
+      scrobbles: {
+        '@attr': { accepted: 0, ignored: 1 },
+        scrobble: { ignoredMessage: { code: '3', '#text': 'Timestamp too old' } },
+      },
+    });
+
+    expect(timestamps.length).toBeGreaterThan(0);
+    // The scrobble step is still mounted but hidden once the stepper advances,
+    // so assert on text content rather than visibility.
+    await expect(page.locator('.v-expansion-panel-header')).toContainText(`${timestamps.length} failed track(s)`);
+    await expect(page.locator('.overall-progress')).toContainText(`0 of ${timestamps.length}`);
+  });
+
+  test('retrying a track re-sends the identical timestamp', async ({ page }) => {
+    // The retry waits out a 30s network cooldown before the second attempt.
+    test.setTimeout(120000);
+
+    const ok = { scrobbles: { '@attr': { accepted: 1, ignored: 0 } } };
+    // Drop the response to the very first attempt, exactly like a connection
+    // reset or a suspended tab would.
+    const timestamps = await runReTaggedImport(page, (attempt) => (attempt === 1 ? 'abort' : ok));
+
+    expect(timestamps.length).toBeGreaterThan(2);
+    // If the retry allocated a fresh second, a request that Last.fm actually
+    // received would be stored a second time as a phantom play — an identical
+    // resend is silently deduplicated instead.
+    expect(timestamps[1]).toBe(timestamps[0]);
+    // Every *other* track still gets its own second.
+    const afterRetry = timestamps.slice(1);
+    expect(new Set(afterRetry).size).toBe(afterRetry.length);
   });
 });


### PR DESCRIPTION
## The bug

Last.fm keys a scrobble on **(user, artist, track, timestamp)** and silently discards any repeat of that tuple. It still returns `accepted=1, ignored=0`, so the loss is undetectable from the response. This is undocumented — I verified it experimentally against the live API (three scrobbles, two distinct timestamps, two plays landed).

`reTagOldListens` assigned the **same `Date` object** to every play moved into the 14-day window. So if you listened to a song five times, four of those were destroyed.

That path runs whenever "Scrobble tracks older than 2 weeks" is ticked: **300 of 386 parses, 80 of 119 people** over the last 60 days.

Separately, `scrobblePlay` discarded the API response, so scrobbles Last.fm explicitly *did* report as ignored were counted as successes.

## The fix

Timestamps for re-tagged plays are allocated **at send time** from a cursor, not baked in at parse time:

```
reTagCursorSec = min(nowSec, max(reTagCursorSec + 1, nowSec - RETAG_BACKFILL_SECONDS))
```

Send-time allocation rather than parse-time matters for two reasons beyond uniqueness:

- Spreading by real track duration only fits ~5,700 tracks in the 14-day window. At 1s spacing, 80,000 fits in 22 hours.
- Absolute timestamps baked in at parse time expire. A queue saved today and resumed three weeks later would be rejected wholesale with ignore code 3.

The cursor persists as a high-water mark (`lastReTagTimestampSec`) so a resumed run can't reuse seconds an earlier run already sent, and is allocated **once per track, not once per attempt** — if the original request reached Last.fm and only the response was lost, an identical resend is deduplicated away, whereas a fresh second would become a phantom play in the user's library.

`scrobblePlay` now returns a `ScrobbleResult`. Parsing defaults to *accepted* on an unrecognised shape, so a surprise response can never invent failures.

## Also in this PR

- **Rate limiting reworked** (`RateLimitTracker`): rolling window of send timestamps with a limit learned adaptively from observed 429s, escalating backoff (5/15/30 min), then an honest give-up-and-save. The old flat 1-minute-forever retry produced 33 recoveries across 2,135 observed rate limits, median 130 minutes — two users sat through 200+ consecutive retries watching a countdown that was never going to work.
- **Resume was silently broken**: a 2-second delayed emit in `AuthenticateStep` undid a resume the user had already started.
- **Completion telemetry**: `original_total_tracks`, `total_succeeded`, `completion_pct`, `is_resumed`, `previously_scrobbled`. Completion was previously measured against the *remaining* chunk, which shrinks on resume — real cases went 81,313 -> 573 and 9,924 -> 40, so a barely-started import looked nearly finished.
- **Migration for in-flight users**: a saved session whose timestamps are >=90% identical (across >=20 tracks) is re-stamped on load.
- **`filterDuplicates` skips re-tagged listens**, whose provisional timestamps would otherwise be matched against real listening history and silently drop import rows.

## Testing

36/36 Playwright tests pass, including four new ones covering distinct timestamps, ignored-scrobble accounting, and retry idempotency. Lint 0 errors, build clean.

## Known unfixed (pre-existing)

- `failedIndices` is always written empty, so failed tracks are never retried on resume.
- `total_succeeded` is an upper bound: re-scrobbling history a user already has is indistinguishable from a fresh play.
