### PR TITLE
Stop the import silently discarding plays and whole files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,32 @@ Two consequences worth knowing before touching this code:
   `originalListenDate`, but checking those would mean fetching the user's whole
   Last.fm history back to the start of the export.
 
+## Import robustness
+
+A Spotify export is split across many `Streaming_History_Audio_*.json` files and
+real ones do arrive damaged — truncated downloads, and large exports that read
+back corrupted on memory-constrained mobile browsers. **A file that can't be
+read or parsed is skipped, not fatal**; the import proceeds with what survived
+and warns the user in the log. Only a ZIP where *every* history file fails is an
+error. Don't "simplify" this back into an early return.
+
+Two Last.fm quirks the validation path has to absorb:
+
+- `track.getInfo` returns tracks with a **missing, empty or non-numeric
+  duration**. `getTrackTimeMs` normalises those to `0`, meaning "unknown", and
+  `removeInvalidListens` treats unknown as a generous 2 minutes. Returning `NaN`
+  instead silently discarded the play, because every comparison against `NaN` is
+  false — so it slipped past the fallback *and* the minimum-length check before
+  failing the final test.
+- Durations are cached per `(artist, track)` on the `LastFm` instance, including
+  permanent "track not found" answers. A listening history is mostly repeat
+  plays, so looking a track up once per *play* multiplied every validation run
+  by the user's average play count, at 250ms of enforced rate buffer each. Rate
+  limits and network errors are deliberately **not** cached.
+
+Timestamps sent to Last.fm are always integer seconds — `from`/`to` window ends
+round outwards so a duplicate-check window can only widen, never miss.
+
 ## Linting
 
 `npm run lint` auto-fixes; `npm run lint:check` (`--no-fix`) is what CI runs, so

--- a/src/api/LastFm.ts
+++ b/src/api/LastFm.ts
@@ -15,6 +15,12 @@ export default class LastFm {
 
   private API_RATE_BUFFER_MS = 250;
 
+  // Track durations are immutable, but a Spotify export is mostly *repeat*
+  // plays — the whole point of the app. Looking a track up once per play rather
+  // than once per distinct track multiplied every validation run by the user's
+  // average play count, at 250ms of enforced rate buffer each.
+  private trackDurationCache = new Map<string, number>();
+
   // NOTE: Last.fm auth tokens are single-use (consumed by auth.getSession), so
   // we deliberately do not persist them. Only the resulting session key is stored.
   private USER_AUTH_TOKEN_LOCALSTORAGE_KEY_LEGACY = 'scrobblifyLfmAuthToken';
@@ -138,8 +144,8 @@ export default class LastFm {
     const requestParams: {[key: string]: string} = {
       method: 'user.getrecenttracks',
       user: this.userName,
-      from: this.dateToSecondsString(from),
-      to: this.dateToSecondsString(to),
+      from: LastFm.dateToSecondsString(from, 'floor'),
+      to: LastFm.dateToSecondsString(to, 'ceil'),
     };
     const response = await this.makeRequest('GET', requestParams);
     const tracks = response.recenttracks.track;
@@ -172,8 +178,8 @@ export default class LastFm {
     const firstParams: {[key: string]: string} = {
       method: 'user.getrecenttracks',
       user: this.userName,
-      from: this.dateToSecondsString(from),
-      to: this.dateToSecondsString(to),
+      from: LastFm.dateToSecondsString(from, 'floor'),
+      to: LastFm.dateToSecondsString(to, 'ceil'),
       limit: PAGE_SIZE.toString(),
       page: '1',
     };
@@ -200,8 +206,8 @@ export default class LastFm {
       const params: {[key: string]: string} = {
         method: 'user.getrecenttracks',
         user: this.userName,
-        from: this.dateToSecondsString(from),
-        to: this.dateToSecondsString(to),
+        from: LastFm.dateToSecondsString(from, 'floor'),
+        to: LastFm.dateToSecondsString(to, 'ceil'),
         limit: PAGE_SIZE.toString(),
         page: page.toString(),
       };
@@ -225,16 +231,40 @@ export default class LastFm {
   public async getTrackTimeMs(trackName: string, trackArtist: string): Promise<number> {
     // TODO this could be better done with musicbrainz/spotify api instead?
     // That way we wouldn't rely on last.fm's track length data
+    const cacheKey = `${trackArtist.toLowerCase()}\u0000${trackName.toLowerCase()}`;
+    const cached = this.trackDurationCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const requestParams = {
       method: 'track.getInfo',
       artist: trackArtist,
       track: trackName,
     };
-    const response = await this.makeRequest('GET', requestParams);
 
-    const listenTime = parseInt(response.track.duration, 10);
+    let response;
+    try {
+      response = await this.makeRequest('GET', requestParams);
+    } catch (e) {
+      // "Track not found" is a permanent answer, and a track a user played 40
+      // times would otherwise be looked up (and rejected) 40 times. Rate limits
+      // and network blips are *not* permanent, so those stay uncached.
+      if (this.isLastFmApiError(e) && !LastFm.isRateLimitError(e)) {
+        this.trackDurationCache.set(cacheKey, 0);
+      }
+      throw e;
+    }
 
-    return listenTime;
+    // Last.fm happily returns a track with a missing, empty or non-numeric
+    // duration. Returning NaN from here poisoned every downstream comparison
+    // (every `NaN > x` is false), which silently discarded the play instead of
+    // falling back to the caller's generous default. 0 means "unknown".
+    const listenTime = parseInt(response.track && response.track.duration, 10);
+    const durationMs = Number.isFinite(listenTime) && listenTime > 0 ? listenTime : 0;
+
+    this.trackDurationCache.set(cacheKey, durationMs);
+    return durationMs;
   }
 
   public async getSession(): Promise<any> {
@@ -479,7 +509,17 @@ export default class LastFm {
     );
   }
 
-  private dateToSecondsString(date: Date): string {
-    return (date.getTime() / 1000).toString();
+  /**
+   * Last.fm expects integer UNIX timestamps. Sending `1784563202.848` is not
+   * something the API promises to handle, and the fractional part appeared in
+   * every `user.getrecenttracks` window the duplicate check requested.
+   *
+   * The two ends round outwards so the window can only ever widen: a duplicate
+   * check that misses a scrobble writes a real duplicate into the user's
+   * library, whereas one that looks slightly too far costs nothing.
+   */
+  private static dateToSecondsString(date: Date, round: 'floor' | 'ceil' = 'floor'): string {
+    const seconds = date.getTime() / 1000;
+    return String(round === 'ceil' ? Math.ceil(seconds) : Math.floor(seconds));
   }
 }

--- a/src/components/UploadStep.vue
+++ b/src/components/UploadStep.vue
@@ -205,6 +205,7 @@ export default Vue.extend({
       // "Unrecognized token ''" error. Parsing incrementally keeps peak memory
       // low because we only ever hold one raw file string at a time.
       let parsedData: SpotifyListen[] = [];
+      const failedFiles: string[] = [];
       for (const name of matchingFiles) {
         const shortName = name.split('/').pop() || name;
 
@@ -213,21 +214,37 @@ export default Vue.extend({
           jsonString = await zip.files[name].async('string');
         } catch (e) {
           trackError('upload.extractFile', e, { file: shortName });
-          this.errorMessage = `Failed to extract "${shortName}" from the ZIP archive.`;
-          this.errorDetails = (e as Error).message || String(e);
-          this.showError = true;
-          return;
+          failedFiles.push(shortName);
+          this.logs.push(`Skipped "${shortName}" — it couldn't be read from the ZIP.`);
+          continue;
         }
 
         try {
           parsedData = parsedData.concat(this.scrobblify.spotifyJsonToListens(jsonString));
         } catch (e) {
           trackError('upload.parseJson', e, { file: shortName });
-          this.errorMessage = `Failed to parse "${shortName}". The JSON data in this file may be malformed.`;
-          this.errorDetails = (e as Error).message || String(e);
-          this.showError = true;
-          return;
+          failedFiles.push(shortName);
+          this.logs.push(`Skipped "${shortName}" — its JSON is malformed or was read incompletely.`);
         }
+      }
+
+      // A Spotify export is split across many files, and one of them being
+      // unreadable used to abandon the entire import. Salvaging the rest turns
+      // a total loss into a partial one; only a complete failure is fatal.
+      if (failedFiles.length > 0) {
+        trackEvent('upload_files_skipped', {
+          skipped_count: failedFiles.length,
+          total_files: matchingFiles.length,
+        });
+      }
+      if (failedFiles.length === matchingFiles.length) {
+        this.errorMessage = `None of the ${matchingFiles.length} history file(s) in this ZIP could be read. The download may be incomplete — try exporting from Spotify again.`;
+        this.errorDetails = `Failed files: ${failedFiles.join(', ')}`;
+        this.showError = true;
+        return;
+      }
+      if (failedFiles.length > 0) {
+        this.logs.push(`Warning: skipped ${failedFiles.length} of ${matchingFiles.length} file(s) — some of your history is missing from this import.`);
       }
       parsedData.sort((a, b) => a.listenDate.getTime() - b.listenDate.getTime());
       this.logs.push(`Found ${parsedData.length} plays in your spotify listening history.`);

--- a/src/scrobblify.ts
+++ b/src/scrobblify.ts
@@ -232,7 +232,13 @@ export default class Scrobblify {
       // This way if they've listened to more than a minute we count it.
       // It's better to err on the side of giving them the scrobble as it will help populate their
       // last.fm history
-      if (currentTrackDurationMs === 0) {
+      //
+      // `!(x > 0)` rather than `=== 0` on purpose: a missing or non-numeric
+      // duration used to arrive here as NaN, and because every comparison
+      // against NaN is false it slipped past this fallback *and* past the
+      // minimum-length check, only to fail `msListened > NaN` at the end. The
+      // play was thrown away — the exact opposite of the intent above.
+      if (!(currentTrackDurationMs > 0)) {
         currentTrackDurationMs = 2 * this.MINUTES_TO_MS;
       }
 

--- a/tests/scrobblify.spec.ts
+++ b/tests/scrobblify.spec.ts
@@ -2,6 +2,7 @@ import {
   test, expect, Page, Route,
 } from '@playwright/test';
 import path from 'path';
+import JSZip from 'jszip';
 import LastFm from '../src/api/LastFm';
 import Scrobble from '../src/models/Scrobble';
 // Shared Last.fm mock, also used by the `npm run dev:mock` interactive script.
@@ -1076,5 +1077,199 @@ test.describe('Re-tagged old plays', () => {
     // Every *other* track still gets its own second.
     const afterRetry = timestamps.slice(1);
     expect(new Set(afterRetry).size).toBe(afterRetry.length);
+  });
+});
+
+test.describe('Import robustness', () => {
+  // Builds a ZIP in-memory so each test can decide exactly how the history
+  // files are damaged, without checking another binary fixture into the repo.
+  async function makeZip(files: Record<string, string>): Promise<Buffer> {
+    const zip = new JSZip();
+    for (const [name, content] of Object.entries(files)) {
+      zip.file(`Spotify Extended Streaming History/${name}`, content);
+    }
+    return zip.generateAsync({ type: 'nodebuffer' });
+  }
+
+  function play(track: string, artist: string, ts: string) {
+    return {
+      ts,
+      master_metadata_track_name: track,
+      master_metadata_album_artist_name: artist,
+      master_metadata_album_album_name: 'An Album',
+      ms_played: 300000,
+    };
+  }
+
+  async function uploadZip(page: Page, buffer: Buffer) {
+    await page.locator('input[type="file"][accept=".zip"]').setInputFiles({
+      name: 'my_spotify_data.zip',
+      mimeType: 'application/zip',
+      buffer,
+    });
+  }
+
+  test('one malformed history file does not throw away the whole import', async ({ page }) => {
+    await goToUploadStep(page);
+
+    const good = JSON.stringify([
+      play('Bohemian Rhapsody', 'Queen', '2024-01-15T10:30:00Z'),
+      play('Yesterday', 'The Beatles', '2024-01-15T10:36:00Z'),
+    ]);
+    // Truncated mid-object, which is what a corrupted or partially-read export
+    // looks like. Real users hit this on large exports.
+    const broken = '[{"ts": "2024-01-15T10:30:00Z", "master_metadata_tra';
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': broken,
+      'Streaming_History_Audio_2024_1.json': good,
+    }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    // The readable file still gets imported...
+    await expect(page.locator('text=Found 2 plays')).toBeVisible({ timeout: 15000 });
+    // ...and the user is told plainly that part of their history is missing.
+    await expect(page.locator('text=skipped 1 of 2 file(s)')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button:has-text("Choose which tracks to scrobble")')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('a ZIP where every history file is unreadable still reports an error', async ({ page }) => {
+    await goToUploadStep(page);
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': 'not json at all',
+    }));
+
+    await page.locator('button:has-text("Find tracks")').click();
+    await expect(page.locator('text=None of the 1 history file(s) in this ZIP could be read')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('a repeated track is looked up once, not once per play', async ({ page }) => {
+    await interceptLastFm(page);
+    const lookups: string[] = [];
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('method') === 'track.getInfo') {
+        lookups.push(`${url.searchParams.get('artist')} - ${url.searchParams.get('track')}`);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ track: { duration: '354000' } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    // The same track six times — exactly the repeat-heavy shape of a real
+    // listening history, and the case the per-play lookup punished hardest.
+    const plays = [];
+    for (let i = 0; i < 6; i++) {
+      plays.push(play('Bohemian Rhapsody', 'Queen', `2024-01-15T10:${10 + i}:00Z`));
+    }
+    plays.push(play('Yesterday', 'The Beatles', '2024-01-15T11:00:00Z'));
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': JSON.stringify(plays),
+    }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('label:has-text("Validate track lengths")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    await expect(page.locator('text=Found 7 valid scrobbles')).toBeVisible({ timeout: 30000 });
+    expect(lookups.length).toBe(2);
+    expect(new Set(lookups).size).toBe(2);
+  });
+
+  test('a track with no duration on Last.fm is kept, not silently discarded', async ({ page }) => {
+    await interceptLastFm(page);
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('method') === 'track.getInfo') {
+        // Last.fm really does return tracks with an empty duration.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ track: { name: 'Obscure B-Side', duration: '' } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': JSON.stringify([
+        play('Obscure B-Side', 'Some Band', '2024-01-15T10:30:00Z'),
+      ]),
+    }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('label:has-text("Validate track lengths")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    // An unparseable duration used to arrive as NaN and fail every comparison,
+    // dropping the play. The documented intent is to give the user the scrobble.
+    await expect(page.locator('text=Found 1 valid scrobbles')).toBeVisible({ timeout: 30000 });
+  });
+
+  test('duplicate-check requests use integer timestamps', async ({ page }) => {
+    await interceptLastFm(page);
+    const ranges: Array<{ from: string; to: string }> = [];
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('method') === 'user.getrecenttracks') {
+        ranges.push({
+          from: url.searchParams.get('from') || '',
+          to: url.searchParams.get('to') || '',
+        });
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            recenttracks: { '@attr': { totalPages: '1', total: '0' }, track: [] },
+          }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': JSON.stringify([
+        // Deliberately *recent* so the play is not re-tagged: re-tagged plays
+        // get provisional timestamps and are exempt from the duplicate check,
+        // so they would never issue a history request at all.
+        play('Bohemian Rhapsody', 'Queen', new Date(Date.now() - 86400000).toISOString()),
+      ]),
+    }));
+
+    await page.locator('label:has-text("Check for duplicates")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+    await expect(page.locator('button:has-text("Choose which tracks to scrobble")')).toBeVisible({ timeout: 30000 });
+
+    expect(ranges.length).toBeGreaterThan(0);
+    for (const range of ranges) {
+      // Last.fm documents UNIX timestamps; "1784563202.848" is not one.
+      expect(range.from).toMatch(/^\d+$/);
+      expect(range.to).toMatch(/^\d+$/);
+    }
   });
 });


### PR DESCRIPTION
Stacked on #72 — base is `fix/scrobble-timestamp-collapse`, so review that one first. GitHub will retarget this to `master` automatically once #72 merges.

I found these by grouping `scrobblify_error` events in PostHog over the last 60 days and tracing each back through the import path. All four silently lose user data.

## 1. A track with no duration on Last.fm was silently discarded

`getTrackTimeMs` did `parseInt(response.track.duration, 10)`. Last.fm happily returns tracks with a missing, empty or non-numeric duration, which gave `NaN`. Because every comparison against `NaN` is false, it slipped past the `=== 0` fallback **and** the minimum-length check, then failed the final `msListened > NaN` — so the play was dropped.

```
parsed: NaN
=== 0?          false   <- missed the "pretend it is 2 minutes" fallback
< 30000?        false   <- missed the minimum-length rejection
isValid?        false   <- dropped anyway, at the last comparison
```

The comment directly above that code says the opposite is intended: *"It's better to err on the side of giving them the scrobble as it will help populate their last.fm history."* Unknown durations now normalise to `0`, which that fallback already handles.

## 2. Durations were fetched once per play, not once per track

Each lookup carries 250ms of enforced rate buffer. A listening history is overwhelmingly *repeat plays* — that is the entire premise of the app — so this multiplied every "Validate track lengths" run by the user's average play count. Now cached per `(artist, track)` on the `LastFm` instance.

Permanent "track not found" answers are cached too, since a track played 40 times was otherwise looked up and rejected 40 times. Rate limits and network errors are deliberately **not** cached.

## 3. Fractional timestamps sent to `user.getrecenttracks`

```
"from":"1784563202.848","to":"1784563622.848"
```

`dateToSecondsString` did `(date.getTime() / 1000).toString()`. Last.fm documents UNIX timestamps; this is the same class of bug already fixed for `track.scrobble`. The two ends now round *outwards*, so a duplicate-check window can only ever look slightly too far — a window that misses writes a real duplicate into the user's library, one that overshoots costs nothing.

## 4. One bad file abandoned the whole import

A Spotify export is split across many `Streaming_History_Audio_*.json` files, and any single one failing to extract or parse returned early and discarded everything. Observed on three separate users:

- `JSON Parse error: Unrecognized token ' '`
- `Expected double-quoted property name in JSON at position 2468006 (line 76959 column 26)`
- `Unexpected token ' ', "    Ma"... is not valid JSON`

The position deep inside the file points at truncated or partially-read data, which the existing code comments already attribute to mobile Safari memory limits on large exports. Damaged files are now skipped with a visible warning naming the file and stating that part of the history is missing; only a ZIP where *every* history file fails is an error.

## Testing

41/41 pass. Five new tests, and I verified each one **fails with the source changes stashed** so they are genuine regression tests rather than tests written to match the new code:

```
5 failed
  one malformed history file does not throw away the whole import
  a ZIP where every history file is unreadable still reports an error
  a repeated track is looked up once, not once per play
  a track with no duration on Last.fm is kept, not silently discarded
  duplicate-check requests use integer timestamps
    Expected pattern: /^\d+$/
    Received string:  "1785028584.929"
```

## Not fixed here

- `vue.errorHandler: Cannot read properties of undefined (reading 'has')` — one occurrence, one user. I traced every `.has(` call site in `SelectStep` and could not construct a path where the non-reactive Sets are unset by the time a computed reads them. Left alone rather than guessed at.
- `spotifyJsonToListens` splits the artist on `', '` and keeps the first element, which mangles artists whose names contain a comma (`Tyler, The Creator` becomes `Tyler`). Real, but there is no reliable way to tell that apart from a genuine multi-artist list without another lookup, so it needs a design decision rather than a patch.
