### PR TITLE
Run PR checks on stacked pull requests too

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,10 @@
 name: PR
 
-on:
-  pull_request:
-    branches: [master]
+# Deliberately not filtered to `branches: [master]`. A PR stacked on another
+# PR targets a feature branch, and with that filter it ran no checks at all —
+# which is exactly the PR most likely to need them, since it is reviewed
+# against a base that has not landed yet.
+on: pull_request
 
 jobs:
   lint:


### PR DESCRIPTION
`pr.yml` was scoped to `on: pull_request: branches: [master]`, which only fires when the PR's **base** is master. A PR stacked on another PR therefore ran no checks at all:

```
$ gh pr checks 73
no checks reported on the 'fix/import-data-loss' branch
```

That is the PR most in need of checks, since it is being reviewed against a base that has not landed yet.

Dropping the filter makes the workflow run on every pull request regardless of base. `ci.yml` still covers push-to-master, so this does not double up.

## Also done outside this repo

The `Protect master - require pull requests` ruleset required a PR but had **no `required_status_checks` rule**, so master could be merged into with CI red or CI never having run. I added it:

- Required contexts: `Lint`, `Build`, `E2E Tests` (pinned to the GitHub Actions app, so another integration cannot report a passing check with the same name)
- Strict policy on: a branch must be up to date with master before it can merge

Note the interaction with stacked PRs: with the strict policy, each merge into master makes every other open PR need an update before it can merge.
