### PR TITLE
Restore import data-loss fixes that never landed on master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,32 @@ Two consequences worth knowing before touching this code:
   `originalListenDate`, but checking those would mean fetching the user's whole
   Last.fm history back to the start of the export.
 
+## Import robustness
+
+A Spotify export is split across many `Streaming_History_Audio_*.json` files and
+real ones do arrive damaged — truncated downloads, and large exports that read
+back corrupted on memory-constrained mobile browsers. **A file that can't be
+read or parsed is skipped, not fatal**; the import proceeds with what survived
+and warns the user in the log. Only a ZIP where *every* history file fails is an
+error. Don't "simplify" this back into an early return.
+
+Two Last.fm quirks the validation path has to absorb:
+
+- `track.getInfo` returns tracks with a **missing, empty or non-numeric
+  duration**. `getTrackTimeMs` normalises those to `0`, meaning "unknown", and
+  `removeInvalidListens` treats unknown as a generous 2 minutes. Returning `NaN`
+  instead silently discarded the play, because every comparison against `NaN` is
+  false — so it slipped past the fallback *and* the minimum-length check before
+  failing the final test.
+- Durations are cached per `(artist, track)` on the `LastFm` instance, including
+  permanent "track not found" answers. A listening history is mostly repeat
+  plays, so looking a track up once per *play* multiplied every validation run
+  by the user's average play count, at 250ms of enforced rate buffer each. Rate
+  limits and network errors are deliberately **not** cached.
+
+Timestamps sent to Last.fm are always integer seconds — `from`/`to` window ends
+round outwards so a duplicate-check window can only widen, never miss.
+
 ## Linting
 
 `npm run lint` auto-fixes; `npm run lint:check` (`--no-fix`) is what CI runs, so

--- a/src/api/LastFm.ts
+++ b/src/api/LastFm.ts
@@ -15,6 +15,12 @@ export default class LastFm {
 
   private API_RATE_BUFFER_MS = 250;
 
+  // Track durations are immutable, but a Spotify export is mostly *repeat*
+  // plays — the whole point of the app. Looking a track up once per play rather
+  // than once per distinct track multiplied every validation run by the user's
+  // average play count, at 250ms of enforced rate buffer each.
+  private trackDurationCache = new Map<string, number>();
+
   // NOTE: Last.fm auth tokens are single-use (consumed by auth.getSession), so
   // we deliberately do not persist them. Only the resulting session key is stored.
   private USER_AUTH_TOKEN_LOCALSTORAGE_KEY_LEGACY = 'scrobblifyLfmAuthToken';
@@ -138,8 +144,8 @@ export default class LastFm {
     const requestParams: {[key: string]: string} = {
       method: 'user.getrecenttracks',
       user: this.userName,
-      from: this.dateToSecondsString(from),
-      to: this.dateToSecondsString(to),
+      from: LastFm.dateToSecondsString(from, 'floor'),
+      to: LastFm.dateToSecondsString(to, 'ceil'),
     };
     const response = await this.makeRequest('GET', requestParams);
     const tracks = response.recenttracks.track;
@@ -172,8 +178,8 @@ export default class LastFm {
     const firstParams: {[key: string]: string} = {
       method: 'user.getrecenttracks',
       user: this.userName,
-      from: this.dateToSecondsString(from),
-      to: this.dateToSecondsString(to),
+      from: LastFm.dateToSecondsString(from, 'floor'),
+      to: LastFm.dateToSecondsString(to, 'ceil'),
       limit: PAGE_SIZE.toString(),
       page: '1',
     };
@@ -200,8 +206,8 @@ export default class LastFm {
       const params: {[key: string]: string} = {
         method: 'user.getrecenttracks',
         user: this.userName,
-        from: this.dateToSecondsString(from),
-        to: this.dateToSecondsString(to),
+        from: LastFm.dateToSecondsString(from, 'floor'),
+        to: LastFm.dateToSecondsString(to, 'ceil'),
         limit: PAGE_SIZE.toString(),
         page: page.toString(),
       };
@@ -225,16 +231,40 @@ export default class LastFm {
   public async getTrackTimeMs(trackName: string, trackArtist: string): Promise<number> {
     // TODO this could be better done with musicbrainz/spotify api instead?
     // That way we wouldn't rely on last.fm's track length data
+    const cacheKey = `${trackArtist.toLowerCase()}\u0000${trackName.toLowerCase()}`;
+    const cached = this.trackDurationCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const requestParams = {
       method: 'track.getInfo',
       artist: trackArtist,
       track: trackName,
     };
-    const response = await this.makeRequest('GET', requestParams);
 
-    const listenTime = parseInt(response.track.duration, 10);
+    let response;
+    try {
+      response = await this.makeRequest('GET', requestParams);
+    } catch (e) {
+      // "Track not found" is a permanent answer, and a track a user played 40
+      // times would otherwise be looked up (and rejected) 40 times. Rate limits
+      // and network blips are *not* permanent, so those stay uncached.
+      if (this.isLastFmApiError(e) && !LastFm.isRateLimitError(e)) {
+        this.trackDurationCache.set(cacheKey, 0);
+      }
+      throw e;
+    }
 
-    return listenTime;
+    // Last.fm happily returns a track with a missing, empty or non-numeric
+    // duration. Returning NaN from here poisoned every downstream comparison
+    // (every `NaN > x` is false), which silently discarded the play instead of
+    // falling back to the caller's generous default. 0 means "unknown".
+    const listenTime = parseInt(response.track && response.track.duration, 10);
+    const durationMs = Number.isFinite(listenTime) && listenTime > 0 ? listenTime : 0;
+
+    this.trackDurationCache.set(cacheKey, durationMs);
+    return durationMs;
   }
 
   public async getSession(): Promise<any> {
@@ -479,7 +509,17 @@ export default class LastFm {
     );
   }
 
-  private dateToSecondsString(date: Date): string {
-    return (date.getTime() / 1000).toString();
+  /**
+   * Last.fm expects integer UNIX timestamps. Sending `1784563202.848` is not
+   * something the API promises to handle, and the fractional part appeared in
+   * every `user.getrecenttracks` window the duplicate check requested.
+   *
+   * The two ends round outwards so the window can only ever widen: a duplicate
+   * check that misses a scrobble writes a real duplicate into the user's
+   * library, whereas one that looks slightly too far costs nothing.
+   */
+  private static dateToSecondsString(date: Date, round: 'floor' | 'ceil' = 'floor'): string {
+    const seconds = date.getTime() / 1000;
+    return String(round === 'ceil' ? Math.ceil(seconds) : Math.floor(seconds));
   }
 }

--- a/src/components/UploadStep.vue
+++ b/src/components/UploadStep.vue
@@ -205,6 +205,7 @@ export default Vue.extend({
       // "Unrecognized token ''" error. Parsing incrementally keeps peak memory
       // low because we only ever hold one raw file string at a time.
       let parsedData: SpotifyListen[] = [];
+      const failedFiles: string[] = [];
       for (const name of matchingFiles) {
         const shortName = name.split('/').pop() || name;
 
@@ -213,21 +214,37 @@ export default Vue.extend({
           jsonString = await zip.files[name].async('string');
         } catch (e) {
           trackError('upload.extractFile', e, { file: shortName });
-          this.errorMessage = `Failed to extract "${shortName}" from the ZIP archive.`;
-          this.errorDetails = (e as Error).message || String(e);
-          this.showError = true;
-          return;
+          failedFiles.push(shortName);
+          this.logs.push(`Skipped "${shortName}" — it couldn't be read from the ZIP.`);
+          continue;
         }
 
         try {
           parsedData = parsedData.concat(this.scrobblify.spotifyJsonToListens(jsonString));
         } catch (e) {
           trackError('upload.parseJson', e, { file: shortName });
-          this.errorMessage = `Failed to parse "${shortName}". The JSON data in this file may be malformed.`;
-          this.errorDetails = (e as Error).message || String(e);
-          this.showError = true;
-          return;
+          failedFiles.push(shortName);
+          this.logs.push(`Skipped "${shortName}" — its JSON is malformed or was read incompletely.`);
         }
+      }
+
+      // A Spotify export is split across many files, and one of them being
+      // unreadable used to abandon the entire import. Salvaging the rest turns
+      // a total loss into a partial one; only a complete failure is fatal.
+      if (failedFiles.length > 0) {
+        trackEvent('upload_files_skipped', {
+          skipped_count: failedFiles.length,
+          total_files: matchingFiles.length,
+        });
+      }
+      if (failedFiles.length === matchingFiles.length) {
+        this.errorMessage = `None of the ${matchingFiles.length} history file(s) in this ZIP could be read. The download may be incomplete — try exporting from Spotify again.`;
+        this.errorDetails = `Failed files: ${failedFiles.join(', ')}`;
+        this.showError = true;
+        return;
+      }
+      if (failedFiles.length > 0) {
+        this.logs.push(`Warning: skipped ${failedFiles.length} of ${matchingFiles.length} file(s) — some of your history is missing from this import.`);
       }
       parsedData.sort((a, b) => a.listenDate.getTime() - b.listenDate.getTime());
       this.logs.push(`Found ${parsedData.length} plays in your spotify listening history.`);

--- a/src/scrobblify.ts
+++ b/src/scrobblify.ts
@@ -232,7 +232,13 @@ export default class Scrobblify {
       // This way if they've listened to more than a minute we count it.
       // It's better to err on the side of giving them the scrobble as it will help populate their
       // last.fm history
-      if (currentTrackDurationMs === 0) {
+      //
+      // `!(x > 0)` rather than `=== 0` on purpose: a missing or non-numeric
+      // duration used to arrive here as NaN, and because every comparison
+      // against NaN is false it slipped past this fallback *and* past the
+      // minimum-length check, only to fail `msListened > NaN` at the end. The
+      // play was thrown away — the exact opposite of the intent above.
+      if (!(currentTrackDurationMs > 0)) {
         currentTrackDurationMs = 2 * this.MINUTES_TO_MS;
       }
 

--- a/tests/scrobblify.spec.ts
+++ b/tests/scrobblify.spec.ts
@@ -2,6 +2,7 @@ import {
   test, expect, Page, Route,
 } from '@playwright/test';
 import path from 'path';
+import JSZip from 'jszip';
 import LastFm from '../src/api/LastFm';
 import Scrobble from '../src/models/Scrobble';
 // Shared Last.fm mock, also used by the `npm run dev:mock` interactive script.
@@ -1076,5 +1077,199 @@ test.describe('Re-tagged old plays', () => {
     // Every *other* track still gets its own second.
     const afterRetry = timestamps.slice(1);
     expect(new Set(afterRetry).size).toBe(afterRetry.length);
+  });
+});
+
+test.describe('Import robustness', () => {
+  // Builds a ZIP in-memory so each test can decide exactly how the history
+  // files are damaged, without checking another binary fixture into the repo.
+  async function makeZip(files: Record<string, string>): Promise<Buffer> {
+    const zip = new JSZip();
+    for (const [name, content] of Object.entries(files)) {
+      zip.file(`Spotify Extended Streaming History/${name}`, content);
+    }
+    return zip.generateAsync({ type: 'nodebuffer' });
+  }
+
+  function play(track: string, artist: string, ts: string) {
+    return {
+      ts,
+      master_metadata_track_name: track,
+      master_metadata_album_artist_name: artist,
+      master_metadata_album_album_name: 'An Album',
+      ms_played: 300000,
+    };
+  }
+
+  async function uploadZip(page: Page, buffer: Buffer) {
+    await page.locator('input[type="file"][accept=".zip"]').setInputFiles({
+      name: 'my_spotify_data.zip',
+      mimeType: 'application/zip',
+      buffer,
+    });
+  }
+
+  test('one malformed history file does not throw away the whole import', async ({ page }) => {
+    await goToUploadStep(page);
+
+    const good = JSON.stringify([
+      play('Bohemian Rhapsody', 'Queen', '2024-01-15T10:30:00Z'),
+      play('Yesterday', 'The Beatles', '2024-01-15T10:36:00Z'),
+    ]);
+    // Truncated mid-object, which is what a corrupted or partially-read export
+    // looks like. Real users hit this on large exports.
+    const broken = '[{"ts": "2024-01-15T10:30:00Z", "master_metadata_tra';
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': broken,
+      'Streaming_History_Audio_2024_1.json': good,
+    }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    // The readable file still gets imported...
+    await expect(page.locator('text=Found 2 plays')).toBeVisible({ timeout: 15000 });
+    // ...and the user is told plainly that part of their history is missing.
+    await expect(page.locator('text=skipped 1 of 2 file(s)')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button:has-text("Choose which tracks to scrobble")')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('a ZIP where every history file is unreadable still reports an error', async ({ page }) => {
+    await goToUploadStep(page);
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': 'not json at all',
+    }));
+
+    await page.locator('button:has-text("Find tracks")').click();
+    await expect(page.locator('text=None of the 1 history file(s) in this ZIP could be read')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('a repeated track is looked up once, not once per play', async ({ page }) => {
+    await interceptLastFm(page);
+    const lookups: string[] = [];
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('method') === 'track.getInfo') {
+        lookups.push(`${url.searchParams.get('artist')} - ${url.searchParams.get('track')}`);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ track: { duration: '354000' } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    // The same track six times — exactly the repeat-heavy shape of a real
+    // listening history, and the case the per-play lookup punished hardest.
+    const plays = [];
+    for (let i = 0; i < 6; i++) {
+      plays.push(play('Bohemian Rhapsody', 'Queen', `2024-01-15T10:${10 + i}:00Z`));
+    }
+    plays.push(play('Yesterday', 'The Beatles', '2024-01-15T11:00:00Z'));
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': JSON.stringify(plays),
+    }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('label:has-text("Validate track lengths")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    await expect(page.locator('text=Found 7 valid scrobbles')).toBeVisible({ timeout: 30000 });
+    expect(lookups.length).toBe(2);
+    expect(new Set(lookups).size).toBe(2);
+  });
+
+  test('a track with no duration on Last.fm is kept, not silently discarded', async ({ page }) => {
+    await interceptLastFm(page);
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('method') === 'track.getInfo') {
+        // Last.fm really does return tracks with an empty duration.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ track: { name: 'Obscure B-Side', duration: '' } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': JSON.stringify([
+        play('Obscure B-Side', 'Some Band', '2024-01-15T10:30:00Z'),
+      ]),
+    }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('label:has-text("Validate track lengths")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    // An unparseable duration used to arrive as NaN and fail every comparison,
+    // dropping the play. The documented intent is to give the user the scrobble.
+    await expect(page.locator('text=Found 1 valid scrobbles')).toBeVisible({ timeout: 30000 });
+  });
+
+  test('duplicate-check requests use integer timestamps', async ({ page }) => {
+    await interceptLastFm(page);
+    const ranges: Array<{ from: string; to: string }> = [];
+    await page.route('https://ws.audioscrobbler.com/**', async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get('method') === 'user.getrecenttracks') {
+        ranges.push({
+          from: url.searchParams.get('from') || '',
+          to: url.searchParams.get('to') || '',
+        });
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            recenttracks: { '@attr': { totalPages: '1', total: '0' }, track: [] },
+          }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+    await page.reload();
+    await expect(page.locator('.upload-step')).toBeVisible({ timeout: 10000 });
+
+    await uploadZip(page, await makeZip({
+      'Streaming_History_Audio_2024_0.json': JSON.stringify([
+        // Deliberately *recent* so the play is not re-tagged: re-tagged plays
+        // get provisional timestamps and are exempt from the duplicate check,
+        // so they would never issue a history request at all.
+        play('Bohemian Rhapsody', 'Queen', new Date(Date.now() - 86400000).toISOString()),
+      ]),
+    }));
+
+    await page.locator('label:has-text("Check for duplicates")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+    await expect(page.locator('button:has-text("Choose which tracks to scrobble")')).toBeVisible({ timeout: 30000 });
+
+    expect(ranges.length).toBeGreaterThan(0);
+    for (const range of ranges) {
+      // Last.fm documents UNIX timestamps; "1784563202.848" is not one.
+      expect(range.from).toMatch(/^\d+$/);
+      expect(range.to).toMatch(/^\d+$/);
+    }
   });
 });


### PR DESCRIPTION
**PR #73 was merged into a branch that had already been merged, so its fixes never reached master.** This restores them.

`fix/import-data-loss` targeted `fix/scrobble-timestamp-collapse` (PR #72). #72 merged to master first, capturing its branch head at `cce7b82`. #73 then merged into that now-stale branch, producing `589e9ea` — which is not an ancestor of master:

```
$ git merge-base --is-ancestor 589e9ea origin/master
NO - NOT on master

$ git grep -c trackDurationCache origin/master -- src/api/LastFm.ts
(no matches)
```

Both PRs show as merged, so this is easy to miss. That is the failure mode of stacking, and it was my call to stack them — apologies.

This branch cherry-picks `874dba3` onto master. The result is byte-identical to the stranded merged state:

```
$ git diff 589e9ea HEAD --stat
(empty)
```

Content is unchanged from what was reviewed and approved in #73: NaN durations no longer discarding plays, per-track duration caching, integer timestamps, and one bad history file no longer aborting the whole import.
