### PR TITLE
Stop mistaking macOS resource-fork sidecars for history files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,20 @@ read or parsed is skipped, not fatal**; the import proceeds with what survived
 and warns the user in the log. Only a ZIP where *every* history file fails is an
 error. Don't "simplify" this back into an early return.
 
+The file matcher is anchored to the **basename** (`/^Streaming_History_Audio_.*\.json$/`
+tested against `name.split('/').pop()`), and that anchoring is load-bearing.
+Testing the unanchored pattern against the full ZIP path also matched
+`__MACOSX/._Streaming_History_Audio_*.json` — the AppleDouble sidecar macOS
+writes for every entry when an archive is created or re-zipped on a Mac. There
+is exactly one per real file, so the count doubled, every sidecar failed
+`JSON.parse`, and the user was warned that half their history was missing when
+none of it was. In telemetry this looked exactly like corruption: the giveaway
+was that `skipped_count` was always precisely half of `total_files`, every
+affected user was on macOS, and all the failures landed within ~400ms of the
+parse starting (far too fast for the memory-exhaustion case this path exists
+for). The sidecars are also why some parse errors quote `"    Ma"` — that's the
+`Mac OS X` marker inside the AppleDouble header, not export data.
+
 Two Last.fm quirks the validation path has to absorb:
 
 - `track.getInfo` returns tracks with a **missing, empty or non-numeric

--- a/src/components/UploadStep.vue
+++ b/src/components/UploadStep.vue
@@ -184,10 +184,20 @@ export default Vue.extend({
         this.showError = true;
         return;
       }
-      const audioFilePattern = /Streaming_History_Audio_.*\.json$/;
-      const matchingFiles = Object.keys(zip.files).filter(
-        (name) => audioFilePattern.test(name) && !zip.files[name].dir,
-      );
+      // Anchored to the *basename*, not the full path. macOS writes an
+      // AppleDouble sidecar (`__MACOSX/._<name>`) for every entry when a ZIP is
+      // created or re-zipped on a Mac, so an unanchored test matched one extra
+      // "history file" per real one — doubling the count, failing every sidecar
+      // in JSON.parse, and telling the user half their history was missing when
+      // none of it was.
+      const audioFilePattern = /^Streaming_History_Audio_.*\.json$/;
+      const matchingFiles = Object.keys(zip.files).filter((name) => {
+        if (zip.files[name].dir) {
+          return false;
+        }
+        const baseName = name.split('/').pop() || name;
+        return audioFilePattern.test(baseName);
+      });
 
       if (matchingFiles.length === 0) {
         trackEvent('upload_no_matching_files');

--- a/tests/scrobblify.spec.ts
+++ b/tests/scrobblify.spec.ts
@@ -1313,6 +1313,44 @@ test.describe('Import robustness', () => {
     await expect(page.locator('text=None of the 1 history file(s) in this ZIP could be read')).toBeVisible({ timeout: 15000 });
   });
 
+  test('macOS resource-fork sidecars are not mistaken for history files', async ({ page }) => {
+    // Regression: the pattern was tested against the whole ZIP path and wasn't
+    // anchored, so `__MACOSX/._Streaming_History_Audio_*.json` matched too.
+    // macOS writes one of those per entry when a ZIP is created or re-zipped on
+    // a Mac, which doubled the file count, failed every sidecar in JSON.parse
+    // and warned that half the user's history was missing when none of it was.
+    await goToUploadStep(page);
+
+    const zip = new JSZip();
+    const names = ['Streaming_History_Audio_2024_0.json', 'Streaming_History_Audio_2024_1.json'];
+    zip.file(`Spotify Extended Streaming History/${names[0]}`, JSON.stringify([
+      play('Bohemian Rhapsody', 'Queen', '2024-01-15T10:30:00Z'),
+    ]));
+    zip.file(`Spotify Extended Streaming History/${names[1]}`, JSON.stringify([
+      play('Yesterday', 'The Beatles', '2024-01-15T10:36:00Z'),
+    ]));
+    for (const name of names) {
+      // AppleDouble sidecar: binary, and carrying the "Mac OS X" marker that
+      // showed up in the real parse errors.
+      zip.file(
+        `__MACOSX/Spotify Extended Streaming History/._${name}`,
+        Buffer.from([0x00, 0x05, 0x16, 0x07, 0x00, 0x02, 0x00, 0x00,
+          ...Buffer.from('Mac OS X        \u0000\u0000\u0000\u0000', 'ascii')]),
+      );
+    }
+    await uploadZip(page, await zip.generateAsync({ type: 'nodebuffer' }));
+
+    await page.locator('label:has-text("Scrobble tracks older than 2 weeks")').click();
+    await page.locator('button:has-text("Find tracks")').click();
+
+    // Only the two real files are counted...
+    await expect(page.locator('text=Found 2 audio history file(s) in ZIP')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('text=Found 2 plays')).toBeVisible({ timeout: 15000 });
+    // ...and nothing is reported as damaged, because nothing was.
+    await expect(page.locator('text=skipped')).toHaveCount(0);
+    await expect(page.locator('button:has-text("Choose which tracks to scrobble")')).toBeVisible({ timeout: 15000 });
+  });
+
   test('a repeated track is looked up once, not once per play', async ({ page }) => {
     await interceptLastFm(page);
     const lookups: string[] = [];


### PR DESCRIPTION
## What users were seeing

Every macOS user importing a re-zipped export got this:

```
Found 24 audio history file(s) in ZIP.
Skipped "._Streaming_History_Audio_2015-2017_0.json" — its JSON is malformed or was read incompletely.
… ×12 …
Warning: skipped 12 of 24 file(s) — some of your history is missing from this import.
```

Nothing was missing. All 12 of their real files parsed fine.

## Cause

`UploadStep.vue` matched history files with an unanchored pattern tested against the **full ZIP path**:

```js
const audioFilePattern = /Streaming_History_Audio_.*\.json$/;
```

macOS writes an AppleDouble sidecar — `__MACOSX/._<name>` — for every entry when an archive is created or re-zipped on a Mac. Those paths end in `.json` and contain `Streaming_History_Audio_`, so they matched too. There's exactly one per real file, so the count doubled and every sidecar then failed `JSON.parse`.

```
true  Streaming_History_Audio_2015-2017_0.json
true  __MACOSX/._Streaming_History_Audio_2015-2017_0.json   ← should be false
```

## How the telemetry gave it away

| user | OS | skipped / total |
|---|---|---|
| laurenvickers_ | Mac OS X | 12 / 24 |
| stupidemorat | Mac OS X | 5 / 10 |
| falintouden | Mac OS X | 5 / 10 |
| goopy_monkey | Mac OS X | 5 / 10 |

Three tells, none of which fit real corruption:

1. `skipped_count` was **exactly half** of `total_files`, every time — one sidecar per file
2. Every clustered `upload.parseJson` failure in 30 days came from macOS
3. All 12 of laurenvickers_'s failures landed within **435ms** of the parse starting — far too fast for the mobile memory-exhaustion case this path was built for

The `Unexpected token ' ', "    Ma"...` in the Chrome errors is the `Mac OS X` marker inside the AppleDouble header, not export data.

## Fix

Anchor the match to the basename, which drops the `._` sidecars while still allowing the export's own subdirectory:

```js
const audioFilePattern = /^Streaming_History_Audio_.*\.json$/;
const matchingFiles = Object.keys(zip.files).filter((name) => {
  if (zip.files[name].dir) return false;
  const baseName = name.split('/').pop() || name;
  return audioFilePattern.test(baseName);
});
```

## Impact

No data was ever lost — but users were told it was, which is worse than it sounds for a tool whose whole job is moving someone's listening history. It also buried genuine corruption in noise: real damaged-export reports were outnumbered roughly 30:1 by sidecars, and that skip-and-continue path exists precisely to surface the real ones.

## Testing

- New test `macOS resource-fork sidecars are not mistaken for history files` builds a ZIP the way macOS does — two real files plus two `__MACOSX/.../._*` AppleDouble entries — and asserts 2 files are found, 2 plays imported, and nothing reported as skipped. **Verified it fails without the fix** (finds 4 files).
- All 6 `Import robustness` tests pass.
- `npm run lint:check` 0 errors, `npm run build` clean.
