### PR TITLE
Keep a pacing stretch open across freed slots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,17 @@ Pacing waits under `PACING_COUNTDOWN_THRESHOLD_MS` (10s) are a plain sleep that
 leaves the scrobbling UI up; only longer waits show the paused panel and
 countdown.
 
+A stretch does **not** end at the first track that needs no wait. One free slot
+is just the slot that track is about to consume, after which the window is full
+again, so `msUntilBurstSafe()` alternates between a small positive wait and zero
+from one track to the next. Exiting on the first zero therefore replaced "one
+event per track" with "one begin/end *pair* per track" — a 34% reduction where
+~100x was intended. `PACING_EXIT_CLEAR_TRACKS` (3) requires a streak of
+genuinely unimpeded tracks instead, which saturation cannot produce. **The
+`paced_tracks` and `scrobble_pacing_ended` data from 2026-08-04 to 2026-08-10 is
+flap-inflated** — median `paced_tracks` of 1 and ~55% single-track stretches are
+the bug, not user behaviour, and are not comparable with later data.
+
 ### Measuring completion
 
 Do **not** build completion percentages from `scrobbled_tracks / total_tracks`.
@@ -247,3 +258,28 @@ track arrays cheaply. Renaming those fields would silently make them reactive
 and tank performance on big histories.
 
 Warnings (mostly `no-explicit-any`) do not fail the build; only errors do.
+
+## Running the tests
+
+Playwright is the only test framework here — there are no unit tests. Analytics
+is disabled on `localhost`, so **a test can never observe a PostHog event**;
+assert on the UI instead.
+
+`playwright.config.ts` sets `reuseExistingServer: true` on port 8080. If a
+`vue-cli-service serve` is already running there **from another checkout or
+worktree, Playwright will happily test that checkout's code instead of yours**
+and say nothing. This has already produced three "verified" results that were
+really the other tree's build. Before trusting a local run — especially one
+verifying a fix — confirm what owns the port:
+
+```powershell
+Get-CimInstance Win32_Process -Filter "ProcessId = $((Get-NetTCPConnection -LocalPort 8080 -State Listen).OwningProcess)" |
+  Select-Object -ExpandProperty CommandLine
+```
+
+or run against a scratch config on its own port with `reuseExistingServer:
+false`. CI is unaffected, since it starts from nothing.
+
+Verify a regression test actually catches its bug with
+`git stash push -- <source file>`, re-run, `git stash pop`. A test that passes
+both ways is testing nothing.

--- a/src/components/ScrobbleStep.vue
+++ b/src/components/ScrobbleStep.vue
@@ -161,6 +161,20 @@ const NETWORK_ERROR_COOLDOWN_SECONDS = Math.ceil(NETWORK_ERROR_COOLDOWN_MS / MS_
 // window saturated by an earlier session has to drain before we can start.
 const PACING_COUNTDOWN_THRESHOLD_MS = 10 * MS_PER_SECOND;
 
+// How many consecutive tracks must need *no* wait before a pacing stretch is
+// considered over.
+//
+// A saturated rolling window frees exactly one slot at a time and the loop
+// consumes it immediately, so `msUntilBurstSafe()` alternates between a small
+// positive wait and zero on every single track. Ending the stretch on the first
+// zero therefore ended it once per track: telemetry showed a median
+// `paced_tracks` of 1 with waits of 4-40ms, i.e. two events per track rather
+// than one per stretch. At saturation two zero-wait tracks in a row are
+// impossible, so requiring a short streak keeps one continuous stretch, while
+// still exiting promptly when the window genuinely clears or the adaptive
+// burst limit is raised and frees a block of slots at once.
+const PACING_EXIT_CLEAR_TRACKS = 3;
+
 const MAX_CONSECUTIVE_FAILURES = 10;
 
 // Re-tagged plays (see Scrobble.reTagged) are stamped at send time, starting
@@ -225,6 +239,9 @@ export default Vue.extend({
       pacingStartedAtMs: 0,
       pacedTracks: 0,
       pacedWaitMs: 0,
+      // Consecutive tracks that needed no pacing wait. See
+      // PACING_EXIT_CLEAR_TRACKS — a single free slot does not end a stretch.
+      unpacedStreak: 0,
       // Mirrors of RateLimitTracker state. The tracker itself is deliberately
       // non-reactive (see created()), so these are refreshed explicitly.
       burstCount: 0,
@@ -383,6 +400,7 @@ export default Vue.extend({
      * to call unconditionally — it is a no-op when we were not pacing.
      */
     endPacing() {
+      this.unpacedStreak = 0;
       if (!this.pacing) {
         return;
       }
@@ -493,6 +511,7 @@ export default Vue.extend({
           // Reported once for the whole stretch, not once per track: the window
           // only ever frees one slot at a time, so this branch is taken for
           // every remaining track once the limit is reached.
+          this.unpacedStreak = 0;
           this.beginPacing(tracker, burstWaitMs);
           this.pacedTracks += 1;
           this.pacedWaitMs += burstWaitMs;
@@ -508,8 +527,14 @@ export default Vue.extend({
             await this.sleep(burstWaitMs);
           }
           this.syncRateLimitCounters();
-        } else {
-          this.endPacing();
+        } else if (this.pacing) {
+          // One free slot is not the end of a throttled stretch — it is the one
+          // slot this track is about to consume, after which the window is full
+          // again. Only a run of genuinely unimpeded tracks means we are clear.
+          this.unpacedStreak += 1;
+          if (this.unpacedStreak >= PACING_EXIT_CLEAR_TRACKS) {
+            this.endPacing();
+          }
         }
 
         // Daily ceiling: a rolling 24h window, so it frees up gradually rather

--- a/tests/scrobblify.spec.ts
+++ b/tests/scrobblify.spec.ts
@@ -773,6 +773,114 @@ test.describe('Session Resume', () => {
     expect(finished).toBe(true);
   });
 
+  test('a throttled stretch is continuous, it does not restart on every freed slot', async ({ page }) => {
+    // Regression: the stretch ended the moment `msUntilBurstSafe()` returned 0.
+    // But a saturated window frees exactly one slot, which the very next track
+    // consumes — so the state flapped once per track, and what should have been
+    // a single pacing stretch became one begin/end pair per scrobble. Telemetry
+    // showed a median `paced_tracks` of 1 with waits of 4-40ms.
+    test.setTimeout(120000);
+    await interceptLastFm(page);
+    // Every reply takes the same time, so the reproduction does not hinge on
+    // browser overhead landing inside some window. The alternation comes from
+    // the seeded history instead (see below), which the app cannot outrun.
+    const REPLY_MS = 600;
+    await page.route('https://ws.audioscrobbler.com/**', async (route: Route) => {
+      const params = new URLSearchParams(
+        route.request().method() === 'POST'
+          ? route.request().postData() || ''
+          : new URL(route.request().url()).search,
+      );
+      if (params.get('method') === 'track.scrobble') {
+        await new Promise((resolve) => { setTimeout(resolve, REPLY_MS); });
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ scrobbles: { '@attr': { accepted: 1, ignored: 0 } } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto('/#/scrobble');
+    await mockLastFmAuth(page);
+
+    // A full window, seeded so that slots free in *pairs*: two sends share an
+    // expiry, then nothing for SLOT_PAIR_GAP_MS. That makes the alternation
+    // structural rather than a race — the first track of each pair always waits
+    // and the second always finds a slot already free, whatever the machine is
+    // doing. Real histories produce the same alternation through network jitter
+    // around the steady-state spacing, just less predictably.
+    //
+    // The pairs are spread to just under the full 10 minute window so the oldest
+    // is about to expire; bunching them tighter would leave the window blocked
+    // for minutes before the first slot appeared.
+    const SLOT_PAIR_GAP_MS = 2400;
+    const SETUP_LEAD_MS = 8000;
+    const anchor = Date.now() + SETUP_LEAD_MS;
+    const sendTimestamps = Array.from({ length: 500 }, (_, k) => {
+      const pair = Math.floor(k / 2);
+      // The +1 keeps the array strictly ascending without meaningfully
+      // separating the two halves of a pair.
+      return anchor - (249 - pair) * SLOT_PAIR_GAP_MS + (k % 2);
+    });
+    const tracks = Array.from({ length: 24 }, (_, n) => ({
+      track: `Track ${n + 1}`,
+      artist: `Artist ${n + 1}`,
+      album: '',
+      timestamp: Date.UTC(2024, 0, n + 1),
+    }));
+    await seedSavedState(page, buildState({
+      totalTracks: 24,
+      completedIndices: [],
+      tracks,
+      originalTotalTracks: 24,
+      originalSucceededCount: 0,
+      sendTimestamps,
+    }));
+    await page.reload();
+
+    await expect(page.locator('text=Resume previous session?')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Resume', exact: true }).click();
+    await expect(page.locator('text=24 tracks ready to scrobble')).toBeVisible({ timeout: 5000 });
+    await page.waitForTimeout(2500);
+    await page.getByRole('button', { name: 'Scrobble', exact: true }).click();
+
+    const notice = page.locator('text=Pacing to stay under');
+    await expect(notice).toBeVisible({ timeout: 20000 });
+
+    // Count how often the notice comes *back* after going away. Counting
+    // reappearances rather than disappearances deliberately ignores the last
+    // one, which is the stretch legitimately ending as the queue drains.
+    let everVisible = false;
+    let hiddenSinceVisible = false;
+    let reappearances = 0;
+    let finished = false;
+    for (let i = 0; i < 1200 && !finished; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await page.waitForTimeout(50);
+      // eslint-disable-next-line no-await-in-loop
+      const visible = await notice.isVisible();
+      if (visible) {
+        if (hiddenSinceVisible) {
+          reappearances += 1;
+          hiddenSinceVisible = false;
+        }
+        everVisible = true;
+      } else if (everVisible) {
+        hiddenSinceVisible = true;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      finished = await page.locator('text=Finished scrobbling').isVisible();
+    }
+
+    expect(finished).toBe(true);
+    // The window stays saturated for the whole run, so there is exactly one
+    // stretch and it should never have restarted.
+    expect(reappearances).toBe(0);
+  });
+
   test('a manual pause saves, offers a way back, and does not re-send the in-flight track', async ({ page }) => {
     // Regression: "Pause & Save" set `paused` but not `stopped`, so the paused
     // panel rendered a *disabled* "Wait Here" button and waited forever for an


### PR DESCRIPTION
## What

Preventive pacing was supposed to report **once per throttled stretch**. PR #76 shipped that, but the stretch ended on the first track that needed no wait — and a saturated rolling window frees exactly one slot at a time, which the loop consumes immediately. So `msUntilBurstSafe()` alternates between a fraction of a second and zero from one track to the next, and the stretch ended roughly every other track.

Net effect: instead of ~1 event per stretch, we got a begin/end **pair** per track. A 34% reduction where ~100x was intended.

## Evidence from production (post-#76 deploy)

| day | stretches | paced tracks | events per paced track | single-track stretches |
| --- | --- | --- | --- | --- |
| 08-09 | 447 | 1,354 | 0.66 | 57% |
| 08-08 | 439 | 1,232 | 0.71 | 52% |

Median `paced_tracks` is **1**. A single user's timeline shows the shape plainly — waits of 4ms and 6ms, `burst_count` sitting exactly on `burst_limit`:

```
13:20:07.469  scrobble_paused        wait_ms=4
13:20:07.983  scrobble_pacing_ended  paced_tracks=1
13:20:20.740  scrobble_paused        wait_ms=6
13:20:21.171  scrobble_pacing_ended  paced_tracks=1
```

## Fix

`PACING_EXIT_CLEAR_TRACKS = 3` — require a streak of genuinely unimpeded tracks before leaving the paced state. Saturation cannot produce three zero-wait tracks in a row, so the stretch stays open for as long as the throttling lasts. A window that really has cleared, or an adaptive burst-limit raise that frees a block of slots at once, still exits within three tracks.

`RateLimitTracker` is deliberately untouched: one-slot-at-a-time is the right answer for throughput, it was only the wrong thing to read as "the throttling is over".

## Test

`a throttled stretch is continuous, it does not restart on every freed slot` seeds the burst window so slots free in **pairs**, making the alternation structural rather than a race — the first track of each pair always waits, the second always finds a slot free. It counts how often the pacing notice comes *back* after disappearing (counting reappearances rather than disappearances ignores the last one, which is the stretch legitimately ending as the queue drains).

Verified against `git stash push -- src/components/ScrobbleStep.vue`: **11 reappearances without the fix, 0 with**.

An earlier attempt varied the mocked reply latency around the steady-state spacing instead. That does not work: the send rate is capped by the window no matter how fast Last.fm answers, so the loop drifts permanently ahead, pacing ends once and never restarts, and *both* the fixed and the broken code pass.

## Also

Documents a local Playwright footgun that hid this through three "verified" runs. `playwright.config.ts` sets `reuseExistingServer: true` on a fixed port, so a `vue-cli-service serve` already running from **another checkout or worktree** gets tested instead of yours, silently. CI is unaffected — it starts from nothing.

## Data note

`paced_tracks` / `scrobble_pacing_ended` between 2026-08-04 and this deploy are flap-inflated and not comparable with later data. Recorded in AGENTS.md alongside the existing note about the 07-27 to 07-29 window.
